### PR TITLE
Support variable precision SR

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This combination of features makes the library versatile for scientific computin
 ## Requirements
 
 - clang, clang++
+- parallel ([install](https://www.gnu.org/software/parallel/))
 - **bazelisk** ([install](https://github.com/bazelbuild/bazelisk/releases))
   
 ## Install

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -6,6 +6,10 @@
 #define _GNU_SOURCE
 #endif
 #include <unistd.h>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
 
 #if defined(PRISM_SR_SCALAR_INL_H) == defined(HWY_TARGET_TOGGLE)
 #ifdef PRISM_SR_SCALAR_INL_H
@@ -25,59 +29,126 @@ namespace rng = prism::scalar::xoshiro::HWY_NAMESPACE;
 
 template <typename T> auto isnumber(const T a, const T b) -> bool {
   using U = typename prism::utils::IEEE754<T>::U;
-  // fast check for a or b is not 0, inf or nan
   debug_start();
   constexpr auto naninf_mask = prism::utils::IEEE754<T>::inf_nan_mask;
+  constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
   prism::utils::binaryN<T> a_bits = {.f = a};
   prism::utils::binaryN<T> b_bits = {.f = b};
   const U a_uint = a_bits.u;
   const U b_uint = b_bits.u;
-  const bool ret =
-      ((a_uint != 0) and ((a_uint & naninf_mask) != naninf_mask)) and
-      ((b_uint != 0) and ((b_uint & naninf_mask) != naninf_mask));
+
+  const int32_t t = prism::sr::get_virtual_precision<T>();
+  bool ret;
+  if (t < mantissa) {
+    // At reduced virtual precision, zero operands can produce results
+    // that need rounding. Only reject inf/nan.
+    ret = ((a_uint & naninf_mask) != naninf_mask) and
+          ((b_uint & naninf_mask) != naninf_mask);
+  } else {
+    // At hardware precision, zero operands produce exact results.
+    // fast check for a or b is not 0, inf or nan
+    ret = ((a_uint != 0) and ((a_uint & naninf_mask) != naninf_mask)) and
+          ((b_uint != 0) and ((b_uint & naninf_mask) != naninf_mask));
+  }
   debug_print("a_bits = 0x%016x\n", a_uint);
   debug_print("b_bits = 0x%016x\n", b_uint);
-  debug_print("0x%016x & 0x%016x = 0x%016x\n", a_uint, naninf_mask,
-              a_uint & naninf_mask);
-  debug_print("0x%016x & 0x%016x = 0x%016x\n", b_uint, naninf_mask,
-              b_uint & naninf_mask);
   debug_print("isnumber(%.13a, %.13a) = %d\n", a, b, ret);
   debug_end();
   return ret;
 }
 
-template <typename T> inline auto round(const T sigma, const T tau) -> T {
+// Virtual Stochastic Rounding
+//
+// Based on the algorithm in Fasi and Mikaitis: Algorithms for Stochastically
+// Rounded Elementary Arithmetic Operations, originally implemented in Verrou,
+// extended to
+//  - support fma op
+//  - support variable precision
+//
+// Given sigma + tau (an error-free representation of the exact result x),
+// returns SR_t(x): the stochastically rounded result at virtual precision t.
+//
+// The result is returned directly.
+//
+// Proof of exact sign evaluation for D = (rho - pi) + tau:
+//
+// 1. |rho - pi| > |tau|
+//    In this case, (rho - pi) might suffer rounding error in float.
+//    However, since |tau| is bounded by 0.5 * ULP_hardware, and the
+//    distance to the zero-boundary is greater than |tau|, the rounding
+//    error cannot pull the result across zero. The boolean outcome of the
+//    sign check remains invariant to the rounding.
+//
+// 2. |rho - pi| <= |tau|
+//    Since |tau| < 0.5 * ULP_hardware, this condition implies rho and pi
+//    share the same exponent and thus satisfy the Sterbenz Lemma
+//    (y/2 <= x <= 2y). Thus, the subtraction (rho - pi) is exact.
+//
+//    (rho - pi) + tau can be inexact but we are only interested in its sign
+//    and IEEE-754 guarantees monotonic rounding.
+// ------------------------------------------------------------------------
+template <typename T>
+inline auto round(const T sigma, const T tau) -> T {
+  const int32_t t = prism::sr::get_virtual_precision<T>();
   using prism::utils::get_exponent;
   using prism::utils::get_predecessor_abs;
   using prism::utils::IEEE754;
   using prism::utils::pow2;
-  debug_start();
-  if (tau == 0) {
-    debug_end();
-    return 0;
-  }
-  constexpr int32_t mantissa = IEEE754<T>::mantissa;
-  const bool sign_tau = tau < 0;
-  const bool sign_sigma = sigma < 0;
-  const int32_t eta = (sign_tau != sign_sigma)
-                          ? get_exponent(get_predecessor_abs(sigma))
-                          : get_exponent(sigma);
-  const T ulp = (sign_tau ? -1 : 1) * pow2<T>(eta - mantissa);
-  const T z = rng::uniform(T{});
-  const T pi = ulp * z;
-  const T rnd = (std::abs(tau + pi) >= std::abs(ulp)) ? ulp : 0;
 
-  debug_print("z     = %+.13a\n", z);
-  debug_print("sigma = %+.13a\n", sigma);
-  debug_print("tau   = %+.13a\n", tau);
-  debug_print("eta   = %d\n", eta);
-  debug_print("pi    = %+.13a\n", pi);
-  debug_print("tau+pi= %+.13a\n", tau + pi);
-  debug_print("ulp   = %+.13a\n", ulp);
-  debug_print("sr_round(%+.13a, %+.13a, %+.13a) = %+.13a\n", sigma, tau, z,
-              rnd);
+  debug_start();
+
+  // compute trunc_t(sigma), the truncated value at precision t
+  const T trunc = prism::sr::truncate_mantissa(sigma, t);
+
+  // rho is the distance from sigma to trunc
+  // the computation is exact in IEEE-754
+  const T rho = sigma - trunc;
+
+  // x = sigma + tau is exactly representable in precision t
+  if (rho == 0 && tau == 0) {
+    debug_end();
+    return trunc;
+  }
+
+  // The distance between x and the truncated representable at precision t is
+  // noted delta = x - trunc = rho + tau, with rho > tau
+  const bool sign_tau = (tau < 0);
+  const bool sign_rho = (rho < 0);
+  const bool sign_trunc = (trunc < 0);
+  const bool sign_delta = (rho == 0) ? sign_tau : sign_rho;
+  const T sign_dir = sign_delta ? T{-1} : T{1};
+
+  // If the distance pushes us in the opposite direction of our value,
+  // we are moving towards zero, so the predecessor might drop an exponent.
+  const int32_t eta = (sign_delta != sign_trunc)
+                          ? get_exponent(get_predecessor_abs(trunc))
+                          : get_exponent(trunc);
+
+  // Compute ulp at precision t
+  const T ulp_t = sign_dir * pow2<T>(eta - t);
+
+  // We sample pi in Uniform(0, ulp_t)
+  const T z = rng::uniform(T{});
+  const T pi = ulp_t * z;
+
+  // We want to check if P < |x - trunc| where P = abs(pi).
+  // We evaluate this by checking the sign of D:
+  const T D = (rho - pi) + tau;
+
+  // When delta and D have the same sign then the random threshold is crossed
+  // and we must round-up
+  const T rnd = (D * sign_dir >= 0) ? ulp_t : T{0};
+
+  debug_print("z         = %+.13a\n", z);
+  debug_print("sigma     = %+.13a\n", sigma);
+  debug_print("trunc     = %+.13a\n", trunc);
+  debug_print("rho       = %+.13a\n", rho);
+  debug_print("eta       = %d\n", eta);
+  debug_print("ulp_t     = %+.13a\n", ulp_t);
+  debug_print("D         = %+.13a\n", D);
   debug_end();
-  return rnd;
+
+  return trunc + rnd;
 }
 
 template <typename T> inline auto add(const T a, const T b) -> T {
@@ -89,10 +160,10 @@ template <typename T> inline auto add(const T a, const T b) -> T {
   T tau;
   T sigma;
   twosum(a, b, sigma, tau);
-  const T rnd = round(sigma, tau);
-  debug_print("sr_add(%+.13a, %+.13a) = %+.13a + %+.13a\n", a, b, sigma, rnd);
+  const T res = round(sigma, tau);
+  debug_print("sr_add(%+.13a, %+.13a) = %+.13a\n", a, b, res);
   debug_end();
-  return sigma + rnd;
+  return res;
 }
 
 template <typename T> inline auto sub(T a, T b) -> T { return add(a, -b); }
@@ -106,9 +177,9 @@ template <typename T> inline auto mul(T a, T b) -> T {
   T tau;
   T sigma;
   twoprodfma(a, b, sigma, tau);
-  const T rnd = round(sigma, tau);
+  const T res = round(sigma, tau);
   debug_end();
-  return sigma + rnd;
+  return res;
 }
 
 template <typename T> inline auto div(const T a, const T b) -> T {
@@ -126,21 +197,20 @@ template <typename T> inline auto div(const T a, const T b) -> T {
               a, std::fma(-sigma, b, a));
   debug_print("tau = (-%+.13a * %+.13a + %+.13a) / %+.13a\n", -sigma, b, a, b);
 
-  const T rnd = round(sigma, tau);
-  debug_print("sr_div(%+.13a, %+.13a) = %+.13a + %+.13a\n", a, b, sigma, tau);
+  const T res = round(sigma, tau);
+  debug_print("sr_div(%+.13a, %+.13a) = %+.13a\n", a, b, res);
   debug_end();
-  return sigma + rnd;
+  return res;
 }
 
 template <typename T> inline auto sqrt(const T a) -> T {
   const T sigma = std::sqrt(a);
-  if (not std::isfinite(a)) {
+  if (not std::isfinite(a) or a <= 0) {
     return sigma;
   }
   const T tau_p = std::fma(-sigma, sigma, a);
   const T tau = tau_p / (2 * sigma);
-  const T rnd = round(sigma, tau);
-  return sigma + rnd;
+  return round(sigma, tau);
 }
 
 /*
@@ -175,11 +245,10 @@ template <typename T> inline auto fma(const T a, const T b, const T c) -> T {
   twosum(u1, alpha1, beta1, beta2);
   gamma = (beta1 - r1) + beta2;
   r2 = gamma + alpha2;
-  const T rnd = round(r1, r2);
-  debug_print("sr_fma(%+.13a, %+.13a, %+.13a) = %+.13a + %+.13a\n", a, b, c, r1,
-              r2);
+  const T res = round(r1, r2);
+  debug_print("sr_fma(%+.13a, %+.13a, %+.13a) = %+.13a\n", a, b, c, res);
   debug_end();
-  return r1 + rnd;
+  return res;
 }
 
 /* binary32 */

--- a/src/sr_scalar.h
+++ b/src/sr_scalar.h
@@ -1,6 +1,8 @@
 #ifndef __PRISM_SR_SCALAR_H__
 #define __PRISM_SR_SCALAR_H__
 
+#include <cstdint>
+
 namespace prism::sr::scalar {
 
 namespace dynamic_dispatch {

--- a/src/sr_scalar_static.cpp
+++ b/src/sr_scalar_static.cpp
@@ -37,8 +37,8 @@ float addf32(float a, float b) { return HWY_STATIC_DISPATCH(addf32)(a, b); }
 float subf32(float a, float b) { return HWY_STATIC_DISPATCH(subf32)(a, b); }
 float mulf32(float a, float b) { return HWY_STATIC_DISPATCH(mulf32)(a, b); }
 float divf32(float a, float b) { return HWY_STATIC_DISPATCH(divf32)(a, b); }
-float sqrtf32(float a) { return HWY_STATIC_DISPATCH(sqrt)(a); }
-float fmaf32(float a, float b, float c) { return HWY_STATIC_DISPATCH(fma)(a, b, c); }
+float sqrtf32(float a) { return HWY_STATIC_DISPATCH(sqrtf32)(a); }
+float fmaf32(float a, float b, float c) { return HWY_STATIC_DISPATCH(fmaf32)(a, b, c); }
 
 double addf64(double a, double b) { return HWY_STATIC_DISPATCH(addf64)(a, b); }
 double subf64(double a, double b) { return HWY_STATIC_DISPATCH(subf64)(a, b); }

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -420,7 +420,7 @@ HWY_INLINE auto pow2(const D d, const VI n) -> hn::VFromD<D> {
 
   constexpr I mantissa = prism::utils::IEEE754<T>::mantissa;
   constexpr I min_exponent = prism::utils::IEEE754<T>::min_exponent;
-  
+
   // Fast path: check if we can use lookup table (framework for future optimization)
   // For now, use the original computation path for all values
 
@@ -466,105 +466,166 @@ HWY_INLINE auto pow2(const D d, const VI n) -> hn::VFromD<D> {
   return res_float;
 }
 
-/*
-Algorithm 6.6. A Helper Function for Stochastic Rounding
-p = precision
-ε = 2^(1−p)
-1. Function SRround(σ, τ, Z)
-2. Compute round.
-3. if sign(τ) != sign(σ)
-4.     η = get_exponent(pred(|σ|));
-5. else
-6.     η = get_exponent(σ);
-7. ulp = sign(τ) * 2^η * ε;
-8. π = ulp * Z;
-9. if |RN(τ + π)| >= |ulp|
-10.    round = ulp;
-11. else
-12.    round = 0;
-13. return round;
-*/
+template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
+HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
+  const int32_t t = prism::sr::get_virtual_precision<T>();
+  constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
+
+  if (HWY_UNLIKELY(t >= mantissa)) return val;
+
+  using DU = hn::RebindToUnsigned<D>;
+  const DU du{};
+  using U = hn::TFromD<DU>;
+
+  const int32_t shift = mantissa - t;
+  const U mask_val = ~((static_cast<U>(1) << shift) - 1);
+  const auto mask = hn::Set(du, mask_val);
+
+  const auto bits = hn::BitCast(du, val);
+  const auto masked_bits = hn::And(bits, mask);
+  return hn::BitCast(d, masked_bits);
+}
+
+// Virtual Stochastic Rounding (Vector)
+//
+// Based on the algorithm in Fasi and Mikaitis: Algorithms for Stochastically
+// Rounded Elementary Arithmetic Operations, originally implemented in Verrou,
+// extended to
+//  - support fma op
+//  - support variable precision
+//
+// Given sigma + tau (an error-free representation of the exact result x),
+// returns SR_t(x): the stochastically rounded result at virtual precision t.
+//
+// The result is returned directly.
+//
+// Proof of exact sign evaluation for D = (rho - pi) + tau:
+//
+// 1. |rho - pi| > |tau|
+//    In this case, (rho - pi) might suffer rounding error in float.
+//    However, since |tau| is bounded by 0.5 * ULP_hardware, and the
+//    distance to the zero-boundary is greater than |tau|, the rounding
+//    error cannot pull the result across zero. The boolean outcome of the
+//    sign check remains invariant to the rounding.
+//
+// 2. |rho - pi| <= |tau|
+//    Since |tau| < 0.5 * ULP_hardware, this condition implies rho and pi
+//    share the same exponent and thus satisfy the Sterbenz Lemma
+//    (y/2 <= x <= 2y). Thus, the subtraction (rho - pi) is exact.
+//
+//    (rho - pi) + tau can be inexact but we are only interested in its sign
+//    and IEEE-754 guarantees monotonic rounding.
+// ------------------------------------------------------------------------
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   dbg::debug_msg("\n[sr_round] START");
   dbg::debug_vec(d, "[sr_round] σ", sigma);
   dbg::debug_vec(d, "[sr_round] τ", tau);
 
-  // get tag for int with same number of lanes as T
+  const int32_t t = prism::sr::get_virtual_precision<T>();
+  const auto zero = hn::Zero(d);
+  const auto one = hn::Set(d, T{1});
+  const auto neg_one = hn::Set(d, T{-1});
+
+  // compute trunc_t(sigma), the truncated value at precision t
+  const auto trunc = truncate_mantissa(d, sigma);
+
+  // rho is the distance from sigma to trunc
+  // the computation is exact in IEEE-754
+  const auto rho = hn::Sub(sigma, trunc);
+
+  // Early exit: x = sigma + tau is exactly representable in precision t
+  const auto rho_is_zero = hn::Eq(rho, zero);
+  const auto tau_is_zero = hn::Eq(tau, zero);
+  const auto both_zero = hn::And(rho_is_zero, tau_is_zero);
+
+  // The distance between x and the truncated representable at precision t is
+  // noted delta = x - trunc = rho + tau, with rho > tau
+  // sign_delta = sign(tau) if rho == 0 else sign(rho)
+  const auto tau_lt_zero = hn::Lt(tau, zero);
+  const auto rho_lt_zero = hn::Lt(rho, zero);
+  const auto sign_delta = hn::Or(
+      hn::And(rho_is_zero, tau_lt_zero),
+      hn::And(hn::Not(rho_is_zero), rho_lt_zero));
+
+  // sign_dir = -1 if sign_delta else 1
+  const auto sign_dir = hn::IfThenElse(sign_delta, neg_one, one);
+
+  // If the distance pushes us in the opposite direction of our value,
+  // we are moving towards zero, so the predecessor might drop an exponent.
+  const auto sign_trunc = hn::Lt(trunc, zero);
+  const auto sign_diff = hn::Xor(sign_delta, sign_trunc);
+
   using DI = hn::RebindToSigned<D>;
   const DI di{};
-  using I = hn::TFromD<DI>;
-
-  constexpr I mantissa = prism::utils::IEEE754<T>::mantissa;
-
-  const auto zero = hn::Zero(d);
-  const auto sign_tau = hn::Lt(tau, zero);
-  const auto sign_sigma = hn::Lt(sigma, zero);
-
-  const auto z_rng = rng::uniform(T{});
-  using DZ = hn::DFromV<decltype(z_rng)>;
-  const auto z = hn::ResizeBitCast(d, z_rng);
-
-  const auto pred_sigma = get_predecessor_abs(d, sigma);
-
-  // sign_diff = sign_tau != sign_sigma
-  const auto sign_diff = hn::Xor(sign_tau, sign_sigma);
-
   const auto sign_diff_int = hn::RebindMask(di, sign_diff);
+
+  const auto pred_trunc = get_predecessor_abs(d, trunc);
 
   // Cache exponent calculations to avoid redundant computation
   using VI = hn::VFromD<DI>;
-  thread_local static V last_sigma = hn::Zero(d);
-  thread_local static VI last_sigma_exp = hn::Zero(di);
-  thread_local static V last_pred_sigma = hn::Zero(d);
-  thread_local static VI last_pred_sigma_exp = hn::Zero(di);
-  
-  VI sigma_exp, pred_sigma_exp;
-  
-  // Check if we can reuse cached sigma exponent
-  if (HWY_LIKELY(hn::AllTrue(d, hn::Eq(sigma, last_sigma)))) {
-    sigma_exp = last_sigma_exp;
+  thread_local static V last_trunc = hn::Zero(d);
+  thread_local static VI last_trunc_exp = hn::Zero(di);
+  thread_local static V last_pred_trunc = hn::Zero(d);
+  thread_local static VI last_pred_trunc_exp = hn::Zero(di);
+
+  VI trunc_exp, pred_trunc_exp;
+
+  // Check if we can reuse cached trunc exponent
+  if (HWY_LIKELY(hn::AllTrue(d, hn::Eq(trunc, last_trunc)))) {
+    trunc_exp = last_trunc_exp;
   } else {
-    sigma_exp = get_exponent(d, sigma);
-    last_sigma = sigma;
-    last_sigma_exp = sigma_exp;
+    trunc_exp = get_exponent(d, trunc);
+    last_trunc = trunc;
+    last_trunc_exp = trunc_exp;
   }
-  
-  // Check if we can reuse cached pred_sigma exponent
-  if (HWY_LIKELY(hn::AllTrue(d, hn::Eq(pred_sigma, last_pred_sigma)))) {
-    pred_sigma_exp = last_pred_sigma_exp;
+
+  // Check if we can reuse cached pred_trunc exponent
+  if (HWY_LIKELY(hn::AllTrue(d, hn::Eq(pred_trunc, last_pred_trunc)))) {
+    pred_trunc_exp = last_pred_trunc_exp;
   } else {
-    pred_sigma_exp = get_exponent(d, pred_sigma);
-    last_pred_sigma = pred_sigma;
-    last_pred_sigma_exp = pred_sigma_exp;
+    pred_trunc_exp = get_exponent(d, pred_trunc);
+    last_pred_trunc = pred_trunc;
+    last_pred_trunc_exp = pred_trunc_exp;
   }
-  
-  const auto eta = hn::IfThenElse(sign_diff_int, pred_sigma_exp, sigma_exp);
+  const auto eta = hn::IfThenElse(sign_diff_int, pred_trunc_exp, trunc_exp);
   dbg::debug_vec(di, "[sr_round] η", eta, false);
 
-  const auto mantissa_v = hn::Set(di, mantissa);
-  const auto exp = hn::Sub(eta, mantissa_v);
-  const auto abs_ulp = pow2(d, exp);
-  dbg::debug_vec(d, "[sr_round] |ulp|", abs_ulp);
+  // Compute ulp at precision t
+  const auto t_v = hn::Set(di, t);
+  const auto exp = hn::Sub(eta, t_v);
+  const auto abs_ulp_t = pow2(d, exp);
 
-  const auto ulp = hn::CopySign(abs_ulp, tau);
-  dbg::debug_vec(d, "[sr_round] ulp", ulp);
+  // ulp_t = sign_dir * abs_ulp_t
+  const auto ulp_t = hn::Mul(sign_dir, abs_ulp_t);
+  dbg::debug_vec(d, "[sr_round] ulp", ulp_t);
 
-  const auto pi = hn::Mul(ulp, z);
-  dbg::debug_vec(DZ{}, "[sr_round] z raw", z_rng);
-  dbg::debug_vec(d, "[sr_round] z", z);
-  dbg::debug_vec(d, "[sr_round] π", pi);
+  // We sample pi in Uniform(0, ulp_t)
+  const auto z_rng = rng::uniform(T{});
+  const auto z = hn::ResizeBitCast(d, z_rng);
+  const auto pi = hn::Mul(ulp_t, z);
 
-  const auto tau_plus_pi = hn::Add(tau, pi);
-  const auto abs_tau_plus_pi = hn::Abs(tau_plus_pi);
-  dbg::debug_vec(d, "[sr_round] |τ|+π", abs_tau_plus_pi);
+  // We want to check if P < |x - trunc| where P = abs(pi).
+  // We evaluate this by checking the sign of D:
+  // D = (rho - pi) + tau   (exact sign, see proof above)
+  const auto rho_minus_pi = hn::Sub(rho, pi);
+  const auto D_val = hn::Add(rho_minus_pi, tau);
 
-  const auto ge = hn::Ge(abs_tau_plus_pi, abs_ulp);
-  const auto round = hn::IfThenElse(ge, ulp, zero);
-  dbg::debug_vec(d, "[sr_round] round", round);
+  // When delta and D have the same sign then the random threshold is crossed
+  // and we must round-up: D * sign_dir >= 0
+  const auto D_signed = hn::Mul(D_val, sign_dir);
+  const auto threshold_crossed = hn::Ge(D_signed, zero);
+  const auto rnd = hn::IfThenElseZero(threshold_crossed, ulp_t);
+  dbg::debug_vec(d, "[sr_round] rnd", rnd);
 
+  // result = trunc + rnd, or just trunc if both_zero
+  const auto trunc_plus_rnd = hn::Add(trunc, rnd);
+  const auto res = hn::IfThenElse(both_zero, trunc, trunc_plus_rnd);
+
+  dbg::debug_vec(d, "[sr_round] res", res);
   dbg::debug_msg("[sr_round] END\n");
-  return round;
+
+  return res;
 }
 
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
@@ -573,8 +634,7 @@ HWY_FLATTEN auto add(const D d, const V a, const V b) -> V {
   V sigma;
   V tau;
   twosum(d, a, b, sigma, tau);
-  const auto rounding = round(d, sigma, tau);
-  const auto ret = hn::Add(sigma, rounding);
+  const auto ret = round(d, sigma, tau);
   dbg::debug_vec(d, "[sr_add] res", ret);
   dbg::debug_msg("[sr_add] END\n");
   return ret;
@@ -595,8 +655,7 @@ HWY_FLATTEN auto mul(const D d, const V a, const V b) -> V {
   V sigma;
   V tau;
   twoprodfma(d, a, b, sigma, tau);
-  const auto rounding = round(d, sigma, tau);
-  const auto ret = hn::Add(sigma, rounding);
+  const auto ret = round(d, sigma, tau);
   dbg::debug_vec(d, "[sr_mul] res", ret);
   dbg::debug_msg("[sr_mul] END\n");
 
@@ -636,9 +695,7 @@ HWY_FLATTEN auto div(const D d, const V a, const V b) -> V {
   dbg::debug_vec(d, "[sr_div] τ'", tau_p);
   const auto tau = hn::Div(tau_p, b);
   dbg::debug_vec(d, "[sr_div] τ", tau);
-  const auto rounding = round(d, sigma, tau);
-  dbg::debug_vec(d, "[sr_div] round", rounding);
-  const auto ret = hn::Add(sigma, rounding);
+  const auto ret = round(d, sigma, tau);
   dbg::debug_vec(d, "[sr_div] res", ret);
   dbg::debug_msg("[sr_div] END\n");
 
@@ -654,8 +711,7 @@ HWY_FLATTEN auto sqrt(const D d, const V a) -> V {
   const auto _div = hn::Div(tau_p, sigma);
   const auto half = hn::Set(d, 0.5);
   const auto tau = hn::Mul(half, _div);
-  const auto rounding = round(d, sigma, tau);
-  const auto ret = hn::Add(sigma, rounding);
+  const auto ret = round(d, sigma, tau);
   dbg::debug_vec(d, "[sr_sqrt] res", ret);
   dbg::debug_msg("[sr_sqrt] END\n");
 
@@ -702,8 +758,7 @@ HWY_FLATTEN auto fma(const D d, const V a, const V b, const V c) -> V {
   const auto beta1_sub_r1 = hn::Sub(beta1, r1);
   gamma = hn::Add(beta1_sub_r1, beta2);
   r2 = hn::Add(gamma, alpha2);
-  const auto rounding = round(d, r1, r2);
-  const auto res = hn::Add(r1, rounding);
+  const auto res = round(d, r1, r2);
   dbg::debug_vec(d, "[sr_fma] res", res);
   dbg::debug_msg("[sr_fma] END\n");
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,7 @@
 #define __PRISM_UTILS_H__
 
 #include <cstdint>
+#include <cassert>
 #include <cstring>
 #include <string>
 
@@ -186,5 +187,26 @@ auto pow2_float(int32_t n) -> float;
 auto pow2_double(int64_t n) -> double;
 
 } // namespace prism::utils
+
+namespace prism::sr {
+  // Configurable virtual precision, default to hardware precision.
+  inline thread_local int32_t virtual_precision_f32 = 23;
+  inline thread_local int32_t virtual_precision_f64 = 52;
+
+  template <typename T>
+  inline int32_t get_virtual_precision() {
+    if constexpr (sizeof(T) == 4) return virtual_precision_f32;
+    else return virtual_precision_f64;
+  }
+
+  template <typename T>
+  inline void set_virtual_precision(int32_t t) {
+    const int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
+    assert(t >= 1 && t <= mantissa);
+
+    if constexpr (sizeof(T) == 4) virtual_precision_f32 = t;
+    else virtual_precision_f64 = t;
+  }
+} // namespace prism::sr
 
 #endif // __PRISM_UTILS_H__

--- a/src/utils.h
+++ b/src/utils.h
@@ -207,6 +207,28 @@ namespace prism::sr {
     if constexpr (sizeof(T) == 4) virtual_precision_f32 = t;
     else virtual_precision_f64 = t;
   }
+
+  // Helper to mask off the lower bits of the mantissa to match a virtual precision t
+  template <typename T>
+  inline auto truncate_mantissa(const T val, const int32_t t) -> T {
+    constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
+
+    // If virtual precision meets or exceeds hardware, no truncation needed
+    if (t >= mantissa) return val;
+
+    // Use appropriate unsigned integer type for bit manipulation
+    using UintT = std::conditional_t<sizeof(T) == 8, uint64_t, uint32_t>;
+    UintT bits;
+    std::memcpy(&bits, &val, sizeof(T));
+
+    const int32_t shift = mantissa - t;
+    const UintT mask = ~((static_cast<UintT>(1) << shift) - 1);
+    bits &= mask;
+
+    T res;
+    std::memcpy(&res, &bits, sizeof(T));
+    return res;
+  }
 } // namespace prism::sr
 
 #endif // __PRISM_UTILS_H__

--- a/tests/helper/assert-inl.h
+++ b/tests/helper/assert-inl.h
@@ -152,7 +152,7 @@ void assert_equal_inputs(D d, Args... args) {
   i++;
 }
 
-template <typename T, typename H = typename IEEE754<T>::H>
+template <typename T, typename H = typename prism::utils::IEEE754<T>::H>
 void assert_counter_infnan_values(const DistanceError<H> &distance_error,
                                   Counter<T> &counter, const H reference) {
 
@@ -175,6 +175,8 @@ void assert_counter_infnan_values(const DistanceError<H> &distance_error,
 
   match |= is_nan_reference and is_nan_up;
   match |= is_inf_reference and (reference == counter.up());
+  match |= (counter.up() == static_cast<T>(distance_error.next));
+  match |= (counter.up() == static_cast<T>(distance_error.prev));
 
   if (not match) {
     std::cerr << "Error in nan/inf comparison\n"
@@ -187,8 +189,10 @@ void assert_counter_infnan_values(const DistanceError<H> &distance_error,
 
   const auto is_nan_down = isnan(counter.down());
 
-  match |= is_nan_reference and is_nan_down;
+  match = is_nan_reference and is_nan_down;
   match |= is_inf_reference and (reference == counter.down());
+  match |= (counter.down() == static_cast<T>(distance_error.prev));
+  match |= (counter.down() == static_cast<T>(distance_error.next));
 
   if (not match) {
     std::cerr << "Error in nan/inf comparison\n"
@@ -200,7 +204,7 @@ void assert_counter_infnan_values(const DistanceError<H> &distance_error,
   }
 }
 
-template <typename Op, typename T, typename H = typename IEEE754<T>::H>
+template <typename Op, typename T, typename H = typename prism::utils::IEEE754<T>::H>
 void print_assert_error(const DistanceError<H> &distance_error,
                         Counter<T> &counter, Args<T> args, const double alpha,
                         const int lane, const int lanes,
@@ -209,6 +213,7 @@ void print_assert_error(const DistanceError<H> &distance_error,
   const auto op_name = Op::name;
   const auto *const ftype = typeid(T).name();
   const auto args_str = get_args_str<T, Op>(args, distance_error.reference);
+  const int32_t virtual_precision = prism::sr::get_virtual_precision<T>();
 
   const auto pdown = fmt_proba(distance_error.probability_down);
   const auto pup = fmt_proba(distance_error.probability_up);
@@ -228,6 +233,7 @@ void print_assert_error(const DistanceError<H> &distance_error,
             << "     Lane/#Lanes: " << lane + 1 << "/" << lanes << "\n"
             << "            type: " << ftype << "\n"
             << "              op: " << op_name << "\n"
+            << "    v. precision: " << virtual_precision << "\n"
             << "           alpha: " << alpha << "\n"
             << std::hexfloat << std::setprecision(precision) << args_str
             << std::defaultfloat << "" << "-- theoretical -\n"
@@ -243,7 +249,7 @@ void print_assert_error(const DistanceError<H> &distance_error,
             << std::defaultfloat << flush();
 }
 
-template <typename Op, typename T, typename H = typename IEEE754<T>::H>
+template <typename Op, typename T, typename H = typename prism::utils::IEEE754<T>::H>
 void assert_unique_value_eq_reference(const DistanceError<H> &distance_error,
                                       Counter<T> &counter, Args<T> args,
                                       const double alpha) {
@@ -263,7 +269,6 @@ void assert_unique_value_eq_reference(const DistanceError<H> &distance_error,
       distance_error.next == counter.up()) {
     return;
   }
-
   if (distance_error.error <= prism::utils::IEEE754<T>::min_subnormal) {
     return;
   }
@@ -273,7 +278,7 @@ void assert_unique_value_eq_reference(const DistanceError<H> &distance_error,
   hwy_assert_may_fail<Op>();
 }
 
-template <typename Op, typename T, typename H = typename IEEE754<T>::H>
+template <typename Op, typename T, typename H = typename prism::utils::IEEE754<T>::H>
 void assert_value_eq_reference(const DistanceError<H> &distance_error,
                                Counter<T> &counter, Args<T> args,
                                const double alpha, const int lane,
@@ -290,20 +295,32 @@ void assert_value_eq_reference(const DistanceError<H> &distance_error,
     return;
   }
 
-  if (distance_error.next != counter.up()) {
-    print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
-                           "Value ↑ is not equal to reference");
-    hwy_assert_may_fail<Op>();
-  }
-
-  if (distance_error.prev != counter.down()) {
-    print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
-                           "Value ↓ is not equal to reference");
-    hwy_assert_may_fail<Op>();
+  // Handle cases where there are only two possible values
+  if (counter.size() == 2) {
+    if (counter.down() != static_cast<T>(distance_error.prev)) {
+       print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
+                              "Value ↓ is not equal to reference");
+       hwy_assert_may_fail<Op>();
+    }
+    if (counter.up() != static_cast<T>(distance_error.next)) {
+       print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
+                              "Value ↑ is not equal to reference");
+       hwy_assert_may_fail<Op>();
+    }
+  } else {
+    for (auto const& [val, freq] : counter.data()) {
+      if (val != static_cast<T>(distance_error.prev) && val != static_cast<T>(distance_error.next)) {
+        print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
+                               "Value " + hexfloat(val) + " is not equal to reference bounds [" +
+                               hexfloat(static_cast<T>(distance_error.prev)) + ", " +
+                               hexfloat(static_cast<T>(distance_error.next)) + "]");
+        hwy_assert_may_fail<Op>();
+      }
+    }
   }
 }
 
-template <class M, typename Op, typename T, typename H = typename IEEE754<T>::H>
+template <class M, typename Op, typename T, typename H = typename prism::utils::IEEE754<T>::H>
 void assert_binomial_test(const DistanceError<H> &distance_error,
                           Counter<T> &counter, const BinomialTest &test,
                           Args<T> args, const double alpha, const int lane,
@@ -320,11 +337,11 @@ void assert_binomial_test(const DistanceError<H> &distance_error,
   static auto robust_config = prism::tests::helper::get_robust_test_config();
   robust_config.base_alpha = alpha;
   robust_config.num_tests_estimate = lanes; // Use actual number of lanes for Bonferroni correction
-  
+
   prism::tests::helper::RobustBinomialTest robust_test(robust_config);
   auto pdown = static_cast<double>(distance_error.probability_down);
   auto result = robust_test.test(counter.down_count(), counter.count(), pdown);
-  
+
   if (!result.passed) {
     // Log robust test details for debugging
     std::cerr << "Robust test details:\n"
@@ -333,7 +350,7 @@ void assert_binomial_test(const DistanceError<H> &distance_error,
               << "  Final alpha: " << result.final_alpha << "\n"
               << "  Sample size: " << result.final_sample_size << "\n"
               << "  Failure reason: " << result.failure_reason << "\n";
-    
+
     print_assert_error<Op>(distance_error, counter, args, alpha, lane, lanes,
                            "Robust statistical test rejected null hypothesis!");
     if constexpr (M::is_sr) {
@@ -344,7 +361,7 @@ void assert_binomial_test(const DistanceError<H> &distance_error,
 
 template <class Op, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>, typename... Args>
-auto eval_op(int repetitions, D d, Args... args) -> std::vector<Counter<T>> {
+auto eval_op(int repetitions, D d, T prev, T next, Args... args) -> std::vector<Counter<T>> {
 
 #ifdef SR_DEBUG
   const size_t lanes = 1;
@@ -354,7 +371,10 @@ auto eval_op(int repetitions, D d, Args... args) -> std::vector<Counter<T>> {
 #endif
   Op op{};
 
-  std::vector<Counter<T>> c(lanes);
+  std::vector<Counter<T>> c;
+  c.reserve(lanes);
+  for (size_t i = 0; i < lanes; i++) c.emplace_back(prev, next);
+
   for (int i = 0; i < repetitions; i++) {
     const auto v = op(d, args...);
     for (size_t j = 0; j < lanes; j++) {
@@ -391,9 +411,10 @@ void CheckDistributionResults(D d, const ConfigTest &config, Args... args) {
   // ensure that we have vector of same value
   assert_equal_inputs(d, args...);
 
-  auto counters = eval_op<Op>(config.repetitions, d, args...);
   H reference = Op::reference(scalar_args);
   auto distance_error = compute_distance_error(scalar_args, reference);
+
+  auto counters = eval_op<Op>(config.repetitions, d, static_cast<T>(distance_error.prev), static_cast<T>(distance_error.next), args...);
   assert_errors_eq_ulp<T>(distance_error);
   assert_proba_eq_one<T>(distance_error, reference);
 
@@ -401,8 +422,13 @@ void CheckDistributionResults(D d, const ConfigTest &config, Args... args) {
   for (auto &counter : counters) {
 
     auto count_down = counter.down_count();
-
     if (distance_error.is_exact) {
+      return;
+    }
+
+    // Skip statistical test when one of the representatives overflows to +-inf.
+    if (not isfinite(static_cast<T>(distance_error.prev)) or
+        not isfinite(static_cast<T>(distance_error.next))) {
       return;
     }
 

--- a/tests/helper/common.h
+++ b/tests/helper/common.h
@@ -7,6 +7,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include "src/utils.h"
+
 namespace prism::tests::helper {
 
 struct RoundingMode {
@@ -148,6 +150,21 @@ auto tuple_to_array_impl(const Tuple &t, std::index_sequence<I...>) {
 
 template <typename... T> auto tuple_to_array(const std::tuple<T...> &t) {
   return tuple_to_array_impl(t, std::index_sequence_for<T...>{});
+}
+
+// run tests with different virtual precisions
+template <typename T, class D, class F>
+void RunWithPrecisions(D d, F&& func) {
+  auto default_t = prism::sr::get_virtual_precision<T>();
+  std::vector<int> precisions;
+  if constexpr (sizeof(T) == 4) precisions = {23, 10, 4, 1};
+  else precisions = {52, 26, 8, 1};
+
+  for (int t : precisions) {
+    prism::sr::set_virtual_precision<T>(t);
+    func();
+  }
+  prism::sr::set_virtual_precision<T>(default_t);
 }
 
 } // namespace prism::tests::helper

--- a/tests/helper/counter.h
+++ b/tests/helper/counter.h
@@ -7,68 +7,50 @@ namespace prism::tests::helper {
 
 template <typename T> class Counter {
 private:
-  int _up_count{};
-  int _down_count{};
-  T _down;
-  T _up;
-  std::map<T, int> data;
-  bool _is_finalized = false;
+  std::map<T, int> _data;
+  T _prev_expected;
+  T _next_expected;
 
 public:
-  Counter() = default;
+  Counter(T prev, T next) : _prev_expected(prev), _next_expected(next) {}
+
+  void add(const T &val) {
+    _data[val]++;
+  }
 
   auto operator[](const T &key) -> int & {
-    _is_finalized = false;
-    return data[key];
+    return _data[key];
   }
 
-  void finalize() {
-    if (_is_finalized) {
-      return;
-    }
-
-    auto keys = data.begin();
-    _down = keys->first;
-    _down_count = keys->second;
-    keys++;
-    if (keys == data.end()) {
-      _is_finalized = true;
-      _up = 0;
-      _up_count = 0;
-      return;
-    }
-    _up = keys->first;
-    _up_count = keys->second;
-
-    if (_down > _up) {
-      std::swap(_down, _up);
-      std::swap(_down_count, _up_count);
-    }
-
-    _is_finalized = true;
+  auto get(const T &key) const -> int {
+    auto it = _data.find(key);
+    if (it != _data.end()) return it->second;
+    return 0;
   }
 
-  [[nodiscard]] auto size() const -> int { return data.size(); }
-  [[nodiscard]] auto count() const -> int { return _down_count + _up_count; }
+  [[nodiscard]] auto size() const -> int { return _data.size(); }
 
-  auto down() -> const T & {
-    finalize();
-    return _down;
-  }
-  auto up() -> const T & {
-    finalize();
-    return _up;
+  auto down() const -> T {
+    return _data.empty() ? T{} : _data.begin()->first;
   }
 
-  auto down_count() -> const int & {
-    finalize();
-    return _down_count;
+  auto up() const -> T {
+    return _data.empty() ? T{} : _data.rbegin()->first;
   }
 
-  auto up_count() -> const int & {
-    finalize();
-    return _up_count;
+  auto count() const -> int {
+    int total = 0;
+    for (auto const& [val, freq] : _data) total += freq;
+    return total;
   }
+
+  auto down_count() const -> int { return get(_prev_expected); }
+  auto up_count() const -> int { return get(_next_expected); }
+
+  auto down_expected() const -> T { return _prev_expected; }
+  auto up_expected() const -> T { return _next_expected; }
+
+  const std::map<T, int>& data() const { return _data; }
 };
 }; // namespace prism::tests::helper
 

--- a/tests/helper/distance.h
+++ b/tests/helper/distance.h
@@ -94,7 +94,18 @@ auto is_exact_operation(Args<T> args, const H reference) -> bool {
   is_exact |= isnan(ref_cast);
   is_exact |= isinf(reference);
   is_exact |= isinf(ref_cast);
-  is_exact |= (ref_cast - reference) == 0;
+
+  // Check exactness at the virtual precision, not just hardware precision.  If
+  // an operation is exact in hardware but falls between virtual
+  // representatives, it must still be stochastically rounded.
+  if (!is_exact) {
+    if (prism::sr::get_virtual_precision<T>() < IEEE754<T>::mantissa) {
+      // Truncate ref_cast to virtual precision and check if it matches reference
+      is_exact = (static_cast<H>(prism::sr::truncate_mantissa(ref_cast, prism::sr::get_virtual_precision<T>())) == reference);
+    } else {
+      is_exact = (ref_cast - reference) == 0;
+    }
+  }
 
   return is_exact;
 }
@@ -102,6 +113,9 @@ auto is_exact_operation(Args<T> args, const H reference) -> bool {
 template <typename T, typename H = typename IEEE754<T>::H>
 auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
   T ref_cast = static_cast<T>(reference);
+  if (prism::sr::get_virtual_precision<T>() < IEEE754<T>::mantissa) {
+    ref_cast = prism::sr::truncate_mantissa(ref_cast, prism::sr::get_virtual_precision<T>());
+  }
 
   DistanceError<H> result = {.reference = reference,
                              .error = 0,
@@ -142,19 +156,16 @@ auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
     // casted reference being the next representable value is equal to 1
     result.is_exact = true;
   } else if (not same_binade) {
-    // if the distance between the reference and the casted reference is
-    // exactly
-    // a power of 2, and the reference and the casted reference does not
-    // belong
-    // to the same binade, then the probability of the casted reference
-    // being the next representable value is equal to 0.5, not .75/.25
     const auto ordered = (result.exponent_next < result.exponent_prev);
-    result.probability_down = 0.5;
-    result.probability_up = 0.5;
     H ulp_prev = ordered ? result.ulp : (result.ulp / 2);
     H ulp_next = ordered ? (result.ulp / 2) : result.ulp;
     result.prev = (ref_cast < reference) ? ref_cast : (ref_cast - ulp_prev);
     result.next = (ref_cast < reference) ? (ref_cast + ulp_next) : ref_cast;
+    // For variable precision crossing a binade boundary, the distances might be
+    // asymmetric so we cannot assume fixed 0.5/0.5 probabilities.
+    H distance = result.next - result.prev;
+    result.probability_down = (result.next - reference) / distance;
+    result.probability_up = (reference - result.prev) / distance;
   }
 
   result.set_distance_error(T{});

--- a/tests/helper/operator.h
+++ b/tests/helper/operator.h
@@ -132,7 +132,10 @@ auto get_ulp(T a) -> H {
       return static_cast<H>(IEEE754<T>::min_subnormal);
     }
     int exponent = get_exponent(a);
-    H ulp = std::ldexp(1.0, exponent - IEEE754<T>::mantissa);
+    // Return the ULP corresponding to the virtual precision grid 't'
+    // rather than the hardware mantissa to ensure accurate distance scaling.
+    int t = prism::sr::get_virtual_precision<T>();
+    H ulp = std::ldexp(1.0, exponent - t);
     return ulp;
   }
 }

--- a/tests/helper/tests-inl.h
+++ b/tests/helper/tests-inl.h
@@ -132,7 +132,7 @@ void TestRandom01(TestFunc &&check, D d, const ConfigTest config = {}) {
 template <size_t arity, typename TestFunc, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomNoOverlap(TestFunc &&check, D d, const ConfigTest config = {}) {
-  constexpr auto s2 = IEEE754<T>::precision - 1;
+  const auto s2 = prism::sr::get_virtual_precision<T>();
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -149,7 +149,7 @@ template <size_t arity, typename TestFunc, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomLastBitOverlap(TestFunc &&check, D d,
                               const ConfigTest config = {}) {
-  constexpr auto s2 = IEEE754<T>::precision;
+  const auto s2 = prism::sr::get_virtual_precision<T>() + 1;
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -165,7 +165,7 @@ void TestRandomLastBitOverlap(TestFunc &&check, D d,
 template <size_t arity, typename TestFunc, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomMidOverlap(TestFunc &&check, D d, const ConfigTest config = {}) {
-  constexpr auto s2 = IEEE754<T>::precision / 2;
+  const auto s2 = (prism::sr::get_virtual_precision<T>() + 1) / 2;
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -241,7 +241,7 @@ template <class M, class Op, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomNoOverlap(D d, const ConfigTest &config) {
 
-  constexpr auto s2 = IEEE754<T>::precision - 1;
+  const auto s2 = prism::sr::get_virtual_precision<T>();
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -261,7 +261,7 @@ void TestRandomNoOverlap(D d, const ConfigTest &config) {
 template <class M, class Op, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomLastBitOverlap(D d, const ConfigTest &config) {
-  constexpr auto s2 = IEEE754<T>::precision;
+  const auto s2 = prism::sr::get_virtual_precision<T>() + 1;
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -281,7 +281,7 @@ void TestRandomLastBitOverlap(D d, const ConfigTest &config) {
 template <class M, class Op, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestRandomMidOverlap(D d, const ConfigTest &config) {
-  constexpr auto s2 = IEEE754<T>::precision / 2;
+  const auto s2 = (prism::sr::get_virtual_precision<T>() + 1) / 2;
   const auto _start = [](int s) -> double { return std::ldexp(1.0, s + 1); };
   const auto _end = [](int s) -> double { return std::ldexp(1.0, s + 2); };
 
@@ -299,10 +299,6 @@ void TestRandomMidOverlap(D d, const ConfigTest &config) {
 }
 
 } // namespace prism::tests::helper::distribution::HWY_NAMESPACE
-
-namespace prism::tests::helper::HWY_NAMESPACE {
-
-}; // namespace prism::tests::helper::HWY_NAMESPACE
 
 HWY_AFTER_NAMESPACE();
 

--- a/tests/scalar/test_sr_accuracy.cpp
+++ b/tests/scalar/test_sr_accuracy.cpp
@@ -61,6 +61,8 @@ auto default_repetitions() -> int {
 
 namespace sr = prism::sr::scalar::HWY_NAMESPACE;
 
+ 
+ 
 struct SRAdd : public helper::PrAdd {
   template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
   auto operator()(D d, V a, V b) const -> V {
@@ -122,14 +124,16 @@ struct SRFma : public helper::PrFma {
 };
 
 struct TestExactOperationsAdd {
-  helper::ConfigTest config = {.name = "TestExactOperationsAdd",
-                               .description =
-                                   "Test exact operations for addition",
-                               .repetitions = default_repetitions(),
-                               .alpha = default_alpha};
+  const helper::ConfigTest config = {.name = "TestExactOperationsAdd",
+                                     .description =
+                                         "Test exact operations for addition",
+                                     .repetitions = default_repetitions(),
+                                     .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestExactAdd<M, SRAdd>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestExactAdd<M, SRAdd>(d, config);
+    });
   }
 };
 
@@ -138,14 +142,16 @@ HWY_NOINLINE void TestAllExactOperationsAdd() {
 }
 
 template <class Op> struct TestBasicAssertions {
-  helper::ConfigTest config = {
+  const helper::ConfigTest config = {
       .name = "TestBasicAssertions",
       .description = "Test basic assertions for arithmetic operations",
       .repetitions = default_repetitions(),
       .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestSimpleCase<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestSimpleCase<M, Op>(d, config);
+    });
   }
 };
 
@@ -181,7 +187,7 @@ HWY_NOINLINE void TestAllBasicAssertionsFma() {
 }
 
 template <class Op> struct TestRandom01Assertions {
-  helper::ConfigTest config = {
+  const helper::ConfigTest config = {
       .name = "TestRandom01Assertions",
       .description =
           "Test random numbers in (0,1) assertions for arithmetic operations",
@@ -189,7 +195,9 @@ template <class Op> struct TestRandom01Assertions {
       .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandom01<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandom01<M, Op>(d, config);
+    });
   }
 };
 
@@ -225,14 +233,16 @@ HWY_NOINLINE void TestAllRandom01AssertionsFma() {
 }
 
 template <class Op> struct TestRandomNoOverlapAssertions {
-  helper::ConfigTest config = {
+  const helper::ConfigTest config = {
       .name = "TestRandomNoOverlapAssertions",
       .description = "Test random with no overlap assertions for arithmetic ",
       .repetitions = default_repetitions(),
       .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomNoOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomNoOverlap<M, Op>(d, config);
+    });
   }
 };
 
@@ -274,7 +284,7 @@ HWY_NOINLINE void TestAllRandomNoOverlapAssertionsFma() {
 }
 
 template <class Op> struct TestRandomLastBitOverlap {
-  helper::ConfigTest config = {
+  const helper::ConfigTest config = {
       .name = "TestRandomLastBitOverlap",
       .description =
           "Test random with last bit overlapping assertions for arithmetic ",
@@ -282,7 +292,9 @@ template <class Op> struct TestRandomLastBitOverlap {
       .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomLastBitOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomLastBitOverlap<M, Op>(d, config);
+    });
   }
 };
 
@@ -318,7 +330,7 @@ HWY_NOINLINE void TestAllRandomLastBitOverlapFma() {
 }
 
 template <class Op> struct TestRandomMidOverlap {
-  helper::ConfigTest config = {
+  const helper::ConfigTest config = {
       .name = "TestRandomMidOverlap",
       .description =
           "Test random number with mid overlap assertions for arithmetic",
@@ -326,7 +338,9 @@ template <class Op> struct TestRandomMidOverlap {
       .alpha = default_alpha};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomMidOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomMidOverlap<M, Op>(d, config);
+    });
   }
 };
 

--- a/tests/vector/test_sr_accuracy.cpp
+++ b/tests/vector/test_sr_accuracy.cpp
@@ -67,6 +67,8 @@ auto default_repetitions() -> int {
 
 namespace sr = prism::sr::vector::PRISM_DISPATCH::HWY_NAMESPACE;
 
+ 
+ 
 struct SRAdd : public helper::PrAdd {
   template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
   auto operator()(D d, V a, V b) const -> V {
@@ -117,7 +119,9 @@ struct TestExactOperationsAdd {
                                      .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestExactAdd<M, SRAdd>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestExactAdd<M, SRAdd>(d, config);
+    });
   }
 };
 
@@ -133,7 +137,9 @@ template <class Op> struct TestBasicAssertions {
       .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestSimpleCase<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestSimpleCase<M, Op>(d, config);
+    });
   }
 };
 
@@ -177,7 +183,9 @@ template <class Op> struct TestRandom01Assertions {
       .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandom01<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandom01<M, Op>(d, config);
+    });
   }
 };
 
@@ -220,7 +228,9 @@ template <class Op> struct TestRandomNoOverlapAssertions {
       .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomNoOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomNoOverlap<M, Op>(d, config);
+    });
   }
 };
 
@@ -270,7 +280,9 @@ template <class Op> struct TestRandomLastBitOverlap {
       .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomLastBitOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomLastBitOverlap<M, Op>(d, config);
+    });
   }
 };
 
@@ -314,7 +326,9 @@ template <class Op> struct TestRandomMidOverlap {
       .alpha = get_alpha()};
 
   template <typename T, class D> void operator()(T /*unused*/, D d) {
-    test_distribution::TestRandomMidOverlap<M, Op>(d, config);
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestRandomMidOverlap<M, Op>(d, config);
+    });
   }
 };
 


### PR DESCRIPTION
Add support for variable precision Stochastic Rounding in PRISM.
This enables exploring the impact of mixed or lower precisions in codes.

This extends previous work by Fasi and Mikaitis (and originally implemented in Verrou).
We have changed the algorithm so :
- it supports variable precision (1 <= t <= mantissa), by truncating sigma before applying the rounding logic.
- the comparison code for the random threshold check (D = (rho - pi) + tau) has been reworked to account for the truncation and ensure the sign evaluation is invariant to floating-point rounding errors. A short proof is included with the code.

Implemented scalar and vector version. In the vector version, the exponent caching has been preserved.

Test suite needed some changes to account for tricky cases that are triggered when the virtual precision does not match the hardware one (described in the relevant commit log). We have ensured that the code passes the original test suite at t=mantissa.

