### PR TITLE
Fix SR subnormal test-cases

### DIFF
--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -39,7 +39,7 @@ template <typename T> auto isnumber(const T a, const T b) -> bool {
 
   const int32_t t = prism::sr::get_virtual_precision<T>();
   bool ret;
-  if (t < mantissa) {
+  if ((t - 1) < mantissa) {
     // At reduced virtual precision, zero operands can produce results
     // that need rounding. Only reject inf/nan.
     ret = ((a_uint & naninf_mask) != naninf_mask) and
@@ -125,13 +125,13 @@ inline auto round(const T sigma, const T tau) -> T {
                           : get_exponent(trunc);
 
   // Compute ulp at precision t
-  const T ulp_t = sign_dir * pow2<T>(eta - t);
+  const T ulp_t = sign_dir * pow2<T>(eta - (t - 1));
 
   // For ulp_t subnormals we scale the variables by 2^64 to lift them into the
   // normal range to preserve full random precision when generating pi.
   // (scaling is exact)
   constexpr int32_t min_exp = IEEE754<T>::min_exponent;
-  const T scale = (eta - t <= min_exp) ? pow2<T>(64) : T{1};
+  const T scale = (eta - (t - 1) <= min_exp) ? pow2<T>(64) : T{1};
   const T sc_rho = rho * scale;
   const T sc_tau = tau * scale;
   const T sc_ulp = ulp_t * scale;

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -127,16 +127,25 @@ inline auto round(const T sigma, const T tau) -> T {
   // Compute ulp at precision t
   const T ulp_t = sign_dir * pow2<T>(eta - t);
 
-  // We sample pi in Uniform(0, ulp_t)
+  // For ulp_t subnormals we scale the variables by 2^64 to lift them into the
+  // normal range to preserve full random precision when generating pi.
+  // (scaling is exact)
+  constexpr int32_t min_exp = IEEE754<T>::min_exponent;
+  const T scale = (eta - t <= min_exp) ? pow2<T>(64) : T{1};
+  const T sc_rho = rho * scale;
+  const T sc_tau = tau * scale;
+  const T sc_ulp = ulp_t * scale;
+
+  // We sample pi in Uniform(0, sc_ulp)
   const T z = rng::uniform(T{});
-  const T pi = ulp_t * z;
+  const T pi = sc_ulp * z;
 
   // We want to check if P < |x - trunc| where P = abs(pi).
   // We evaluate this by checking the sign of D:
-  const T D = (rho - pi) + tau;
+  const T D = (sc_rho - pi) + sc_tau;
 
   // When delta and D have the same sign then the random threshold is crossed
-  // and we must round-up
+  // and we must round-up. We use the unscaled ulp_t for the result.
   const T rnd = (D * sign_dir >= 0) ? ulp_t : T{0};
 
   debug_print("z         = %+.13a\n", z);

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -377,12 +377,15 @@ HWY_INLINE auto get_exponent(const D d, const V a) -> VI {
   dbg::debug_vec(di, "[get_exponent] raw_exp", raw_exp);
   dbg::debug_vec(di, "[get_exponent] exp", exp, false);
 
-  const auto res = hn::IfThenZeroElse(is_zero, exp);
 
-  dbg::debug_vec(di, "[get_exponent] res", res, false);
+  const auto raw_exp_is_zero = hn::Eq(raw_exp, hn::Zero(di));
+  const auto min_exponent_v = hn::Set(di, prism::utils::IEEE754<T>::min_exponent);
+  const auto exp_clamped = hn::IfThenElse(raw_exp_is_zero, min_exponent_v, exp);
+
+  dbg::debug_vec(di, "[get_exponent] res", exp_clamped, false);
   dbg::debug_msg("[get_exponent] END\n");
 
-  return res;
+  return exp_clamped;
 }
 
 // Computes 2^x, where x is an integer.
@@ -600,16 +603,28 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   const auto ulp_t = hn::Mul(sign_dir, abs_ulp_t);
   dbg::debug_vec(d, "[sr_round] ulp", ulp_t);
 
-  // We sample pi in Uniform(0, ulp_t)
+  // For ulp_t subnormals we scale the variables by 2^64 to lift them into the
+  // normal range to preserve full random precision when generating pi.
+  // (scaling is exact)
+  constexpr int32_t min_exp = prism::utils::IEEE754<T>::min_exponent;
+  const auto min_exp_v = hn::Set(di, min_exp);
+  const auto is_min_exp = hn::Le(hn::Sub(eta, t_v), min_exp_v);
+  const auto scale =
+      hn::IfThenElse(hn::RebindMask(d, is_min_exp),
+                     hn::Set(d, prism::utils::pow2<T>(64)), one);
+  const auto sc_rho = hn::Mul(rho, scale);
+  const auto sc_tau = hn::Mul(tau, scale);
+  const auto sc_ulp = hn::Mul(ulp_t, scale);
+
+  // We sample pi in Uniform(0, sc_ulp)
   const auto z_rng = rng::uniform(T{});
   const auto z = hn::ResizeBitCast(d, z_rng);
-  const auto pi = hn::Mul(ulp_t, z);
+  const auto pi = hn::Mul(sc_ulp, z);
 
   // We want to check if P < |x - trunc| where P = abs(pi).
   // We evaluate this by checking the sign of D:
   // D = (rho - pi) + tau   (exact sign, see proof above)
-  const auto rho_minus_pi = hn::Sub(rho, pi);
-  const auto D_val = hn::Add(rho_minus_pi, tau);
+  const auto D_val = hn::Add(hn::Sub(sc_rho, pi), sc_tau);
 
   // When delta and D have the same sign then the random threshold is crossed
   // and we must round-up: D * sign_dir >= 0

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -474,13 +474,13 @@ HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
   const int32_t t = prism::sr::get_virtual_precision<T>();
   constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
 
-  if (HWY_UNLIKELY(t >= mantissa)) return val;
+  if (HWY_UNLIKELY((t - 1) >= mantissa)) return val;
 
   using DU = hn::RebindToUnsigned<D>;
   const DU du{};
   using U = hn::TFromD<DU>;
 
-  const int32_t shift = mantissa - t;
+  const int32_t shift = mantissa - (t - 1);
   const U mask_val = ~((static_cast<U>(1) << shift) - 1);
   const auto mask = hn::Set(du, mask_val);
 
@@ -595,7 +595,7 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   dbg::debug_vec(di, "[sr_round] η", eta, false);
 
   // Compute ulp at precision t
-  const auto t_v = hn::Set(di, t);
+  const auto t_v = hn::Set(di, (t-1));
   const auto exp = hn::Sub(eta, t_v);
   const auto abs_ulp_t = pow2(d, exp);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -120,7 +120,7 @@ inline auto get_exponent(T a) -> I {
   debug_start();
   if (a == 0) {
     debug_end();
-    return 0;
+    return IEEE754<T>::min_exponent;
   }
   using U = typename IEEE754<T>::U;
   constexpr I bias = IEEE754<T>::bias;
@@ -135,6 +135,14 @@ inline auto get_exponent(T a) -> I {
   debug_print("a = 0x%016x\n", a_bits);
   const auto raw_exp = (a_bits & exponent_mask) >> mantissa;
   debug_print("raw exponent = %d\n", raw_exp);
+
+  if (raw_exp == 0) {
+    debug_print("get_exponent(%.13a) = %d (subnormal)\n", a,
+                IEEE754<T>::min_exponent);
+    debug_end();
+    return IEEE754<T>::min_exponent;
+  }
+
   const I exp = raw_exp - bias;
   debug_print("get_exponent(%.13a) = %d\n", a, exp);
   debug_end();

--- a/src/utils.h
+++ b/src/utils.h
@@ -198,8 +198,8 @@ auto pow2_double(int64_t n) -> double;
 
 namespace prism::sr {
   // Configurable virtual precision, default to hardware precision.
-  inline thread_local int32_t virtual_precision_f32 = 23;
-  inline thread_local int32_t virtual_precision_f64 = 52;
+  inline thread_local int32_t virtual_precision_f32 = 24;
+  inline thread_local int32_t virtual_precision_f64 = 53;
 
   template <typename T>
   inline int32_t get_virtual_precision() {
@@ -209,8 +209,8 @@ namespace prism::sr {
 
   template <typename T>
   inline void set_virtual_precision(int32_t t) {
-    const int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
-    assert(t >= 1 && t <= mantissa);
+    constexpr int32_t precision = prism::utils::IEEE754<T>::mantissa + 1;
+    assert(t >= 2 && t <= precision);
 
     if constexpr (sizeof(T) == 4) virtual_precision_f32 = t;
     else virtual_precision_f64 = t;
@@ -222,14 +222,14 @@ namespace prism::sr {
     constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
 
     // If virtual precision meets or exceeds hardware, no truncation needed
-    if (t >= mantissa) return val;
+    if (t >= mantissa + 1) return val;
 
     // Use appropriate unsigned integer type for bit manipulation
     using UintT = std::conditional_t<sizeof(T) == 8, uint64_t, uint32_t>;
     UintT bits;
     std::memcpy(&bits, &val, sizeof(T));
 
-    const int32_t shift = mantissa - t;
+    const int32_t shift = mantissa - (t - 1);
     const UintT mask = ~((static_cast<UintT>(1) << shift) - 1);
     bits &= mask;
 

--- a/tests/helper/assert-inl.h
+++ b/tests/helper/assert-inl.h
@@ -412,7 +412,7 @@ void CheckDistributionResults(D d, const ConfigTest &config, Args... args) {
   assert_equal_inputs(d, args...);
 
   H reference = Op::reference(scalar_args);
-  auto distance_error = compute_distance_error(scalar_args, reference);
+  auto distance_error = compute_distance_error<Op>(scalar_args, reference);
 
   auto counters = eval_op<Op>(config.repetitions, d, static_cast<T>(distance_error.prev), static_cast<T>(distance_error.next), args...);
   assert_errors_eq_ulp<T>(distance_error);

--- a/tests/helper/common.h
+++ b/tests/helper/common.h
@@ -158,9 +158,9 @@ template <typename T, class D, class F> void RunWithPrecisions(D d, F &&func) {
   auto default_t = prism::sr::get_virtual_precision<T>();
   std::vector<int> precisions;
   if constexpr (sizeof(T) == 4)
-    precisions = {23, 10, 4, 1};
+    precisions = {23, 20, 10, 4, 1};
   else
-    precisions = {52, 26, 8, 1};
+    precisions = {52, 49, 26, 8, 1};
 
   for (int t : precisions) {
     prism::sr::set_virtual_precision<T>(t);

--- a/tests/helper/common.h
+++ b/tests/helper/common.h
@@ -158,9 +158,9 @@ template <typename T, class D, class F> void RunWithPrecisions(D d, F &&func) {
   auto default_t = prism::sr::get_virtual_precision<T>();
   std::vector<int> precisions;
   if constexpr (sizeof(T) == 4)
-    precisions = {23, 20, 10, 4, 1};
+    precisions = {24, 21, 11, 5, 2};
   else
-    precisions = {52, 49, 26, 8, 1};
+    precisions = {53, 50, 27, 9, 2};
 
   for (int t : precisions) {
     prism::sr::set_virtual_precision<T>(t);

--- a/tests/helper/distance.h
+++ b/tests/helper/distance.h
@@ -147,12 +147,11 @@ auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
   result.exponent_next = get_exponent(result.next);
   result.exponent_prev = get_exponent(result.prev);
 
-  const bool error_small = result.error < IEEE754<T>::ulp;
-
+  const bool error_small = result.error <IEEE754<T>::ulp * result.ulp;
   const bool same_binade = result.exponent_next == result.exponent_prev;
 
   if (error_small) {
-    // if the error is smaller than an ulp, then the probability of the
+    // if the error is smaller 2^-52 * result.ulp; then the probability of the
     // casted reference being the next representable value is equal to 1
     result.is_exact = true;
   } else if (not same_binade) {

--- a/tests/helper/distance.h
+++ b/tests/helper/distance.h
@@ -99,7 +99,7 @@ auto is_exact_operation(Args<T> args, const H reference) -> bool {
   // an operation is exact in hardware but falls between virtual
   // representatives, it must still be stochastically rounded.
   if (!is_exact) {
-    if (prism::sr::get_virtual_precision<T>() < IEEE754<T>::mantissa) {
+    if (prism::sr::get_virtual_precision<T>() < (IEEE754<T>::mantissa + 1)) {
       // Truncate ref_cast to virtual precision and check if it matches reference
       is_exact = (static_cast<H>(prism::sr::truncate_mantissa(ref_cast, prism::sr::get_virtual_precision<T>())) == reference);
     } else {
@@ -113,7 +113,7 @@ auto is_exact_operation(Args<T> args, const H reference) -> bool {
 template <typename Op = void, typename T, typename H = typename IEEE754<T>::H>
 auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
   T ref_cast = static_cast<T>(reference);
-  if (prism::sr::get_virtual_precision<T>() < IEEE754<T>::mantissa) {
+  if (prism::sr::get_virtual_precision<T>() < (IEEE754<T>::mantissa + 1)) {
     ref_cast = prism::sr::truncate_mantissa(ref_cast, prism::sr::get_virtual_precision<T>());
   }
 

--- a/tests/helper/distance.h
+++ b/tests/helper/distance.h
@@ -77,7 +77,7 @@ auto relative_distance(const T1 a, const T2 b) -> std::common_type_t<T1, T2> {
   return absolute_distance(a, b) / absolute_distance(a);
 }
 
-template <typename T, typename H = typename IEEE754<T>::H>
+template <typename Op = void, typename T, typename H = typename IEEE754<T>::H>
 auto is_exact_operation(Args<T> args, const H reference) -> bool {
   T ref_cast = static_cast<T>(reference);
 
@@ -110,7 +110,7 @@ auto is_exact_operation(Args<T> args, const H reference) -> bool {
   return is_exact;
 }
 
-template <typename T, typename H = typename IEEE754<T>::H>
+template <typename Op = void, typename T, typename H = typename IEEE754<T>::H>
 auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
   T ref_cast = static_cast<T>(reference);
   if (prism::sr::get_virtual_precision<T>() < IEEE754<T>::mantissa) {
@@ -130,7 +130,7 @@ auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
                              .msg = "Not initialized",
                              .is_exact = false};
 
-  if (is_exact_operation(args, reference)) {
+  if (is_exact_operation<Op>(args, reference)) {
     result.is_exact = true;
     result.probability_down = 1;
     result.msg = "Exact operation";
@@ -147,13 +147,38 @@ auto compute_distance_error(Args<T> args, H reference) -> DistanceError<H> {
   result.exponent_next = get_exponent(result.next);
   result.exponent_prev = get_exponent(result.prev);
 
-  const bool error_small = result.error <IEEE754<T>::ulp * result.ulp;
   const bool same_binade = result.exponent_next == result.exponent_prev;
 
-  if (error_small) {
-    // if the error is smaller 2^-52 * result.ulp; then the probability of the
-    // casted reference being the next representable value is equal to 1
+  // if the float128 error is smaller 2^-52 * result.ulp; then the probability of the
+  // casted reference being the next representable value is equal to 1
+  const bool rel_error_small = result.error < IEEE754<T>::ulp * result.ulp;
+
+  // Fasi and Mikaitis note that twodiv and twosqrt are approximations
+  // eg. with 1.0 / 2^128, unscaled twodiv will flush tau to zero.
+  // For twodiv, we could conditionally scale to fix this, but it's a performance tradeoff.
+  // here we stick with the twodiv and twosqrt proposed in Fasi and Mikaitis paper
+  bool eft_underflow = false;
+  if constexpr (!std::is_void_v<Op> && std::is_base_of_v<PrDiv, Op>) {
+    // tau is too small
+    const bool final_underflow = result.error < IEEE754<T>::min_subnormal;
+    // twodiv FMA (tau * b) is flushed
+    const auto approx_remainder = result.error * std::abs(args[1]);
+    const bool intermediate_underflow =
+        approx_remainder < IEEE754<T>::min_subnormal;
+    eft_underflow = final_underflow || intermediate_underflow;
+  } else if constexpr (!std::is_void_v<Op> && std::is_base_of_v<PrSqrt, Op>) {
+    // twosqrt FMA approximation: r ~ tau * 2 * sigma is flushed
+    const auto approx_remainder =
+        (result.error * T(2.0) * result.ulp) / IEEE754<T>::ulp;
+    eft_underflow = approx_remainder < IEEE754<T>::min_subnormal;
+  }
+
+  // ignore exact results and twodiv / twosqrt underflows
+  if (rel_error_small || eft_underflow) {
     result.is_exact = true;
+  }
+
+  if (result.is_exact) {
   } else if (not same_binade) {
     const auto ordered = (result.exponent_next < result.exponent_prev);
     H ulp_prev = ordered ? result.ulp : (result.ulp / 2);

--- a/tests/helper/operator.h
+++ b/tests/helper/operator.h
@@ -137,7 +137,7 @@ auto get_ulp(T a) -> H {
     // Return the ULP corresponding to the virtual precision grid 't'
     // rather than the hardware mantissa to ensure accurate distance scaling.
     int t = prism::sr::get_virtual_precision<T>();
-    H ulp = std::ldexp(1.0, exponent - t);
+    H ulp = std::ldexp(1.0, exponent - (t - 1));
     return ulp;
   }
 }

--- a/tests/helper/operator.h
+++ b/tests/helper/operator.h
@@ -86,24 +86,29 @@ template <typename T> auto is_subnormal(const T a) -> bool {
 }
 
 template <typename T> auto get_exponent(T a) -> int {
-  int exp = 0;
+  constexpr int min_exp_quad = -16382; // Minimum exponent for quad precision
   if (a == 0) {
-    return 0;
+    if constexpr (std::is_same_v<T, Float128_boost>) {
+      return min_exp_quad;
+    } else {
+      return prism::utils::IEEE754<T>::min_exponent;
+    }
   }
   if constexpr (std::is_same_v<T, Float128_boost>) {
     const auto res =
         boost::multiprecision::floor(boost::multiprecision::log2(abs(a)));
-    return static_cast<int>(res);
+    return std::max(static_cast<int>(res), min_exp_quad);
   } else {
     using U = typename IEEE754<T>::U;
     U u;
     std::memcpy(&u, &a, sizeof(T));
     u &= IEEE754<T>::exponent_mask_scaled;
     u >>= IEEE754<T>::mantissa;
-    exp = static_cast<int>(u);
-    exp -= IEEE754<T>::bias;
+    if (u == 0) {
+      return prism::utils::IEEE754<T>::min_exponent;
+    }
+    return static_cast<int>(u) - IEEE754<T>::bias;
   }
-  return exp;
 }
 
 template <typename T> auto is_power_of_2(T a) -> bool {
@@ -128,9 +133,6 @@ auto get_ulp(T a) -> H {
     H ulp = boost::multiprecision::ldexp(one, exponent - mantissa);
     return ulp;
   } else {
-    if (is_subnormal(a)) {
-      return static_cast<H>(IEEE754<T>::min_subnormal);
-    }
     int exponent = get_exponent(a);
     // Return the ULP corresponding to the virtual precision grid 't'
     // rather than the hardware mantissa to ensure accurate distance scaling.

--- a/tests/helper/tests-inl.h
+++ b/tests/helper/tests-inl.h
@@ -178,6 +178,38 @@ void TestRandomMidOverlap(TestFunc &&check, D d, const ConfigTest config = {}) {
   TestRandom<arity>(check, d, config, ranges);
 }
 
+template <size_t arity, typename TestFunc, class D, class V = hn::VFromD<D>,
+          typename T = hn::TFromD<D>>
+void TestSubnormal(TestFunc &&check, D d, ConfigTest config = {}) {
+  const auto subnormals = helper::SubnormalCases<T>();
+  const size_t n = subnormals.size();
+
+  if constexpr (arity == 1) {
+    for (auto a : subnormals) {
+      check(d, config, std::forward_as_tuple(hn::Set(d, a)));
+    }
+  } else if constexpr (arity == 2) {
+    for (size_t i = 0; i < n; ++i) {
+      for (size_t j = i; j < n; ++j) {
+        check(d, config,
+              std::forward_as_tuple(hn::Set(d, subnormals[i]),
+                                    hn::Set(d, subnormals[j])));
+      }
+    }
+  } else if constexpr (arity == 3) {
+    for (size_t i = 0; i < n; ++i) {
+      for (size_t j = i; j < n; ++j) {
+        for (size_t k = j; k < n; ++k) {
+          check(d, config,
+                std::forward_as_tuple(hn::Set(d, subnormals[i]),
+                                      hn::Set(d, subnormals[j]),
+                                      hn::Set(d, subnormals[k])));
+        }
+      }
+    }
+  }
+}
+
 template <int arity, typename TestFunc, class D, class V = hn::VFromD<D>,
           typename T = hn::TFromD<D>>
 void TestBinade(TestFunc &&test, D d, const ConfigTest config = {}, int n = 0) {
@@ -296,6 +328,14 @@ void TestRandomMidOverlap(D d, const ConfigTest &config) {
   generic::TestRandom<Op::arity>(
       helper::CheckDistributionResultsWrapper<args_t, M, Op, D>, d, config,
       ranges);
+}
+
+template <class M, class Op, class D, class V = hn::VFromD<D>,
+          typename T = hn::TFromD<D>>
+void TestSubnormal(D d, const ConfigTest &config) {
+  using args_t = typename TupleN<Op::arity, V>::type;
+  generic::TestSubnormal<Op::arity>(
+      helper::CheckDistributionResultsWrapper<args_t, M, Op, D>, d, config);
 }
 
 } // namespace prism::tests::helper::distribution::HWY_NAMESPACE

--- a/tests/helper/tests.h
+++ b/tests/helper/tests.h
@@ -30,6 +30,14 @@ template <typename T> auto SimpleCase() -> std::vector<T> {
   return simple_case;
 }
 
+template <typename T> auto SubnormalCases() -> std::vector<T> {
+  if constexpr (sizeof(T) == 4) {
+    return {1.5e-40f, 2.8e-41f, std::numeric_limits<T>::denorm_min()};
+  } else {
+    return {1.5e-315, 2.8e-316, std::numeric_limits<T>::denorm_min()};
+  }
+}
+
 template <typename T, int arity, int repetitions = default_repetitions,
           typename TestFunc = std::any>
 void TestBasic(TestFunc &&test) {

--- a/tests/scalar/BUILD
+++ b/tests/scalar/BUILD
@@ -29,7 +29,7 @@ cc_test_gen_scalar(
 
 cc_test_lib_gen(
     name = "sr-accuracy",
-    size = "small",
+    size = "medium",
     src = [
         ":test_sr_accuracy.cpp",
     ],
@@ -38,7 +38,7 @@ cc_test_lib_gen(
 
 cc_test_lib_gen(
     name = "sr-accuracy-dbg",
-    size = "small",
+    size = "medium",
     src = [
         ":test_sr_accuracy.cpp",
     ],

--- a/tests/scalar/test_get_exponent.cpp
+++ b/tests/scalar/test_get_exponent.cpp
@@ -16,13 +16,12 @@ template <typename T> auto get_exponent(T a) -> int32_t {
   auto cls = std::fpclassify(a);
   switch (cls) {
   case FP_ZERO:
-    return 0;
+  case FP_SUBNORMAL:
+    return std::numeric_limits<T>::min_exponent - 1;
   case FP_NORMAL:
     std::frexp(a, &exp);
     return exp - 1;
     break;
-  case FP_SUBNORMAL:
-    return std::numeric_limits<T>::min_exponent - 2;
   case FP_INFINITE:
   case FP_NAN:
     return std::numeric_limits<T>::max_exponent;

--- a/tests/scalar/test_sr_accuracy.cpp
+++ b/tests/scalar/test_sr_accuracy.cpp
@@ -375,6 +375,51 @@ HWY_NOINLINE void TestAllRandomMidOverlapFma() {
   hn::ForFloat3264Types(hn::ForPartialVectors<TestRandomMidOverlapFma>());
 }
 
+template <class Op> struct TestSubnormalAssertions {
+  const helper::ConfigTest config = {
+      .name = "TestSubnormalAssertions",
+      .description = "Test subnormal assertions for arithmetic operations",
+      .repetitions = default_repetitions(),
+      .alpha = default_alpha};
+
+  template <typename T, class D> void operator()(T /*unused*/, D d) {
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestSubnormal<M, Op>(d, config);
+    });
+  }
+};
+
+using TestSubnormalAssertionsAdd = TestSubnormalAssertions<SRAdd>;
+using TestSubnormalAssertionsSub = TestSubnormalAssertions<SRSub>;
+using TestSubnormalAssertionsMul = TestSubnormalAssertions<SRMul>;
+using TestSubnormalAssertionsDiv = TestSubnormalAssertions<SRDiv>;
+using TestSubnormalAssertionsSqrt = TestSubnormalAssertions<SRSqrt>;
+using TestSubnormalAssertionsFma = TestSubnormalAssertions<SRFma>;
+
+HWY_NOINLINE void TestAllSubnormalAssertionsAdd() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsAdd>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsSub() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsSub>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsMul() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsMul>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsDiv() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsDiv>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsSqrt() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsSqrt>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsFma() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsFma>());
+}
+
 } // namespace
 } // namespace prism::HWY_NAMESPACE
 HWY_AFTER_NAMESPACE();
@@ -421,6 +466,12 @@ HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllRandomMidOverlapMul);
 HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllRandomMidOverlapDiv);
 HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllRandomMidOverlapSqrt);
 HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllRandomMidOverlapFma);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsAdd);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsSub);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsMul);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsDiv);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsSqrt);
+HWY_EXPORT_AND_TEST_P(SRScalarAccuracyTest, TestAllSubnormalAssertionsFma);
 HWY_AFTER_TEST();
 // NOLINTEND
 

--- a/tests/vector/test_get_exponent.cpp
+++ b/tests/vector/test_get_exponent.cpp
@@ -36,13 +36,12 @@ template <typename T> auto get_exponent(T a) -> int32_t {
   auto cls = std::fpclassify(a);
   switch (cls) {
   case FP_ZERO:
-    return 0;
+  case FP_SUBNORMAL:
+    return std::numeric_limits<T>::min_exponent - 1;
   case FP_NORMAL:
     std::frexp(a, &exp);
     return exp - 1;
     break;
-  case FP_SUBNORMAL:
-    return std::numeric_limits<T>::min_exponent - 2;
   case FP_INFINITE:
   case FP_NAN:
     return std::numeric_limits<T>::max_exponent;

--- a/tests/vector/test_sr_accuracy.cpp
+++ b/tests/vector/test_sr_accuracy.cpp
@@ -363,6 +363,51 @@ HWY_NOINLINE void TestAllRandomMidOverlapFma() {
   hn::ForFloat3264Types(hn::ForPartialVectors<TestRandomMidOverlapFma>());
 }
 
+template <class Op> struct TestSubnormalAssertions {
+  const helper::ConfigTest config = {
+      .name = "TestSubnormalAssertions",
+      .description = "Test subnormal assertions for arithmetic operations",
+      .repetitions = default_repetitions(),
+      .alpha = get_alpha()};
+
+  template <typename T, class D> void operator()(T /*unused*/, D d) {
+    helper::RunWithPrecisions<T>(d, [&]() {
+      test_distribution::TestSubnormal<M, Op>(d, config);
+    });
+  }
+};
+
+using TestSubnormalAssertionsAdd = TestSubnormalAssertions<SRAdd>;
+using TestSubnormalAssertionsSub = TestSubnormalAssertions<SRSub>;
+using TestSubnormalAssertionsMul = TestSubnormalAssertions<SRMul>;
+using TestSubnormalAssertionsDiv = TestSubnormalAssertions<SRDiv>;
+using TestSubnormalAssertionsSqrt = TestSubnormalAssertions<SRSqrt>;
+using TestSubnormalAssertionsFma = TestSubnormalAssertions<SRFma>;
+
+HWY_NOINLINE void TestAllSubnormalAssertionsAdd() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsAdd>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsSub() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsSub>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsMul() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsMul>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsDiv() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsDiv>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsSqrt() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsSqrt>());
+}
+
+HWY_NOINLINE void TestAllSubnormalAssertionsFma() {
+  hn::ForFloat3264Types(hn::ForPartialVectors<TestSubnormalAssertionsFma>());
+}
+
 } // namespace
 } // namespace prism::HWY_NAMESPACE
 HWY_AFTER_NAMESPACE();
@@ -408,6 +453,12 @@ HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllRandomMidOverlapMul);
 HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllRandomMidOverlapDiv);
 HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllRandomMidOverlapSqrt);
 HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllRandomMidOverlapFma);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsAdd);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsSub);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsMul);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsDiv);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsSqrt);
+HWY_EXPORT_AND_TEST_P(SRVectorAccuracyTest, TestAllSubnormalAssertionsFma);
 HWY_AFTER_TEST();
 // NOLINTEND
 } // namespace prism::HWY_NAMESPACE


### PR DESCRIPTION
As pointed by @yohanchatelain, with t<53 we can have a bias in SR probabilities with subnormal numbers.
This is due to our `pi = ulp_t * rng::uniform(T{});` computation. If the result is subnormal, pi becomes subnormal and we loose the 52 full random mantissa bits. The exact number of bits lost depends on $t$.

This PR will add a reproducing test case and provide a fix.