### PR TITLE
Add seed getter/setter to public C API with reproducibility tests

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -3,6 +3,7 @@ load("//:constants.bzl", "COPTS", "DEBUG_COPTS", "DYNAMIC_COPTS", "RANDOM_FULLBI
 
 exports_files([
     "prism_api.cpp",
+    "prism_api.h",
     "debug.h",
     "debug_vector-inl.h",
     "eft.h",

--- a/src/prism_api.h
+++ b/src/prism_api.h
@@ -10,30 +10,26 @@
  *                                                                           *\
  ****************************************************************************/
 
-#include "prism_api.h"
-#include "utils.h"
-#include "xoshiro.h"
+#ifndef __PRISM_API_H__
+#define __PRISM_API_H__
 
+#include <stdint.h>
+
+#ifdef __cplusplus
 extern "C" {
+#endif
 
-void interflop_prism_set_default_virtual_precision_binary32(int32_t t) {
-  prism::sr::default_virtual_precision_f32 = t;
-}
+void interflop_prism_set_default_virtual_precision_binary32(int32_t t);
+void interflop_prism_set_default_virtual_precision_binary64(int32_t t);
 
-void interflop_prism_set_default_virtual_precision_binary64(int32_t t) {
-  prism::sr::default_virtual_precision_f64 = t;
-}
+int32_t interflop_prism_get_default_virtual_precision_binary32(void);
+int32_t interflop_prism_get_default_virtual_precision_binary64(void);
 
-int32_t interflop_prism_get_default_virtual_precision_binary32(void) {
-  return prism::sr::default_virtual_precision_f32;
-}
+uint64_t interflop_prism_get_seed(void);
+void interflop_prism_set_seed(uint64_t seed);
 
-int32_t interflop_prism_get_default_virtual_precision_binary64(void) {
-  return prism::sr::default_virtual_precision_f64;
-}
-
-uint64_t interflop_prism_get_seed(void) { return get_user_seed(); }
-
-void interflop_prism_set_seed(uint64_t seed) { set_user_seed(seed); }
-
+#ifdef __cplusplus
 } // extern "C"
+#endif
+
+#endif // __PRISM_API_H__

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <type_traits>
 
-#include "src/debug.h"
+#include "debug.h"
 
 #ifdef __clang__
 using Float128 = __float128;
@@ -203,7 +203,8 @@ namespace prism::sr {
 // Process-wide defaults, set once before main() by vfcwrapper init.
 // Thread-local vars initialize from these so every new thread inherits them.
 inline int32_t default_virtual_precision_f32 = utils::IEEE754<float>::precision;
-inline int32_t default_virtual_precision_f64 = utils::IEEE754<double>::precision;
+inline int32_t default_virtual_precision_f64 =
+    utils::IEEE754<double>::precision;
 
 // Configurable virtual precision, default to hardware precision.
 // NOLINT

--- a/src/xoshiro.h
+++ b/src/xoshiro.h
@@ -3,18 +3,20 @@
 
 #include <random>
 
-__attribute__((unused)) static auto get_user_seed() -> uint64_t {
+// inline with external linkage: static locals are shared across all TUs.
+inline auto seed_state(bool set = false, uint64_t new_seed = 0) -> uint64_t {
   static bool initialized = false;
   static uint64_t seed = 0;
-  if (not initialized) {
-    const char *seed_env_str = "PRISM_SEED";
-    const char *seed_str = getenv(seed_env_str);
+  if (set) {
+    seed = new_seed;
+    initialized = true;
+  } else if (not initialized) {
+    const char *seed_str = getenv("PRISM_SEED");
     if (seed_str != nullptr) {
       char *endptr = nullptr;
       seed = strtoll(seed_str, &endptr, 10);
       if (*endptr != '\0') {
-        // Handle conversion error
-        seed = 0; // or some default value
+        seed = 0;
       }
     } else {
       std::random_device rd;
@@ -23,6 +25,14 @@ __attribute__((unused)) static auto get_user_seed() -> uint64_t {
     initialized = true;
   }
   return seed;
+}
+
+__attribute__((unused)) inline auto get_user_seed() -> uint64_t {
+  return seed_state();
+}
+
+__attribute__((unused)) inline auto set_user_seed(uint64_t seed) -> void {
+  seed_state(true, seed);
 }
 
 #endif // __PRISM_XOSHIRO_H__

--- a/tests/scalar/BUILD
+++ b/tests/scalar/BUILD
@@ -28,6 +28,19 @@ cc_test_gen_scalar(
 # Stochastic Rounding rounding mode
 
 cc_test_lib_gen(
+    name = "seed-api",
+    src = [
+        ":test_seed_api.cpp",
+        "//src:prism_api.h",
+        "//src:xoshiro.h",
+        "//src:random-inl.h",
+        "//src:target_utils.h",
+        "//src:debug_vector-inl.h",
+    ],
+    mode = "dynamic",
+)
+
+cc_test_lib_gen(
     name = "sr-accuracy",
     size = "medium",
     src = [
@@ -111,6 +124,7 @@ cc_test_binary(
 test_suite(
     name = "all",
     tests = [
+        ":seed-api",
         ":sr-accuracy",
         ":test_get_exponent",
         ":test_get_pow2",

--- a/tests/scalar/test_seed_api.cpp
+++ b/tests/scalar/test_seed_api.cpp
@@ -1,0 +1,70 @@
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "hwy/highway.h"
+
+#include "src/prism_api.h"
+#include "src/xoshiro.h"
+
+namespace rng = prism::scalar::xoshiro::HWY_NAMESPACE;
+
+TEST(SeedAPITest, GetSetRoundtrip) {
+  constexpr uint64_t seed = 42;
+  interflop_prism_set_seed(seed);
+  EXPECT_EQ(interflop_prism_get_seed(), seed);
+}
+
+TEST(SeedAPITest, SetOverwritesPreviousValue) {
+  interflop_prism_set_seed(1);
+  EXPECT_EQ(interflop_prism_get_seed(), 1ULL);
+
+  interflop_prism_set_seed(99);
+  EXPECT_EQ(interflop_prism_get_seed(), 99ULL);
+}
+
+TEST(SeedAPITest, ZeroSeed) {
+  interflop_prism_set_seed(0);
+  EXPECT_EQ(interflop_prism_get_seed(), 0ULL);
+}
+
+TEST(SeedAPITest, MaxSeed) {
+  interflop_prism_set_seed(UINT64_MAX);
+  EXPECT_EQ(interflop_prism_get_seed(), UINT64_MAX);
+}
+
+TEST(SeedAPITest, SameSeedSameSequence) {
+  constexpr uint64_t seed = 0xDEADBEEF42ULL;
+  constexpr uint64_t thread_num = 0;
+  constexpr int N = 1000;
+
+  rng::internal::init_rng(seed, thread_num);
+  std::vector<uint64_t> seq1(N);
+  for (auto &v : seq1)
+    v = rng::random();
+
+  rng::internal::init_rng(seed, thread_num);
+  std::vector<uint64_t> seq2(N);
+  for (auto &v : seq2)
+    v = rng::random();
+
+  EXPECT_EQ(seq1, seq2);
+}
+
+TEST(SeedAPITest, DifferentSeedsDifferentSequences) {
+  constexpr uint64_t thread_num = 0;
+  constexpr int N = 1000;
+
+  rng::internal::init_rng(1, thread_num);
+  std::vector<uint64_t> seq1(N);
+  for (auto &v : seq1)
+    v = rng::random();
+
+  rng::internal::init_rng(2, thread_num);
+  std::vector<uint64_t> seq2(N);
+  for (auto &v : seq2)
+    v = rng::random();
+
+  EXPECT_NE(seq1, seq2);
+}
+

--- a/tests/vector/BUILD
+++ b/tests/vector/BUILD
@@ -66,6 +66,17 @@ cc_test_lib_gen(
     dbg = True,
 )
 
+cc_test_lib_gen(
+    name = "seed-api",
+    size = "small",
+    src = [
+        "//src:srcs-xoshiro",
+        "//src:prism_api.h",
+        "//tests/vector:test_seed_api.cpp",
+    ],
+    mode = "dynamic",
+)
+
 # Stochastic rounding library tests
 
 cc_test_lib_gen(
@@ -206,6 +217,7 @@ cc_test_lib_gen(
 test_suite(
     name = "all",
     tests = [
+        ":seed-api",
         ":sr-accuracy",
         ":sr-perf-dynamic",
         ":sr-perf-static",

--- a/tests/vector/test_seed_api.cpp
+++ b/tests/vector/test_seed_api.cpp
@@ -1,0 +1,102 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+// clang-format off
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/vector/test_seed_api.cpp"  // NOLINT
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/tests/test_util-inl.h"
+// clang-format on
+
+#include "src/prism_api.h"
+#include "src/xoshiro.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy::HWY_NAMESPACE {
+namespace {
+
+namespace vrng = prism::vector::xoshiro::HWY_NAMESPACE;
+
+constexpr std::uint64_t kN = 1 << 10;
+
+void TestVector_SameSeedSameSequence() {
+  constexpr uint64_t seed = 0xDEADBEEF42ULL;
+  constexpr uint64_t thread_num = 0;
+
+  const ScalableTag<uint64_t> d;
+  const size_t lanes = Lanes(d);
+  const auto buf1 = hwy::MakeUniqueAlignedArray<uint64_t>(kN);
+  const auto buf2 = hwy::MakeUniqueAlignedArray<uint64_t>(kN);
+
+  interflop_prism_set_seed(seed);
+  vrng::internal::init_rng(interflop_prism_get_seed(), thread_num);
+  for (size_t i = 0; i < kN; i += lanes)
+    Store(vrng::random(uint64_t{}), d, buf1.get() + i);
+
+  interflop_prism_set_seed(seed);
+  vrng::internal::init_rng(interflop_prism_get_seed(), thread_num);
+  for (size_t i = 0; i < kN; i += lanes)
+    Store(vrng::random(uint64_t{}), d, buf2.get() + i);
+
+  for (size_t i = 0; i < kN; i++) {
+    if (buf1[i] != buf2[i]) {
+      std::cerr << "SameSeedSameSequence FAILED at i=" << i << ": " << buf1[i]
+                << " != " << buf2[i] << "\n";
+      HWY_ASSERT(0);
+    }
+  }
+}
+
+void TestVector_DifferentSeedsDifferentSequences() {
+  constexpr uint64_t thread_num = 0;
+
+  const ScalableTag<uint64_t> d;
+  const size_t lanes = Lanes(d);
+  const auto buf1 = hwy::MakeUniqueAlignedArray<uint64_t>(kN);
+  const auto buf2 = hwy::MakeUniqueAlignedArray<uint64_t>(kN);
+
+  interflop_prism_set_seed(1);
+  vrng::internal::init_rng(interflop_prism_get_seed(), thread_num);
+  for (size_t i = 0; i < kN; i += lanes)
+    Store(vrng::random(uint64_t{}), d, buf1.get() + i);
+
+  interflop_prism_set_seed(2);
+  vrng::internal::init_rng(interflop_prism_get_seed(), thread_num);
+  for (size_t i = 0; i < kN; i += lanes)
+    Store(vrng::random(uint64_t{}), d, buf2.get() + i);
+
+  bool all_equal = true;
+  for (size_t i = 0; i < kN; i++) {
+    if (buf1[i] != buf2[i]) {
+      all_equal = false;
+      break;
+    }
+  }
+  if (all_equal) {
+    std::cerr << "DifferentSeedsDifferentSequences FAILED: sequences are "
+                 "identical\n";
+    HWY_ASSERT(0);
+  }
+}
+
+} // namespace
+} // namespace hwy::HWY_NAMESPACE
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace hwy::HWY_NAMESPACE {
+namespace {
+// NOLINTBEGIN
+HWY_BEFORE_TEST(PRISMSeedAPIVectorTest);
+HWY_EXPORT_AND_TEST_P(PRISMSeedAPIVectorTest,
+                      TestVector_SameSeedSameSequence);
+HWY_EXPORT_AND_TEST_P(PRISMSeedAPIVectorTest,
+                      TestVector_DifferentSeedsDifferentSequences);
+// NOLINTEND
+HWY_AFTER_TEST();
+} // namespace
+} // namespace hwy::HWY_NAMESPACE
+HWY_TEST_MAIN();
+#endif // HWY_ONCE


### PR DESCRIPTION
Expose interflop_prism_get_seed/set_seed in prism_api.h and prism_api.cpp. Fix xoshiro.h seed helpers to use inline external linkage so state is shared across translation units. Add scalar and vector reproducibility tests verifying that the same (seed, thread_number) pair always produces the same RNG sequence.