### PR TITLE
Untied RN mode

### DIFF
--- a/src/prism_api.cpp
+++ b/src/prism_api.cpp
@@ -36,4 +36,12 @@ uint64_t interflop_prism_get_seed(void) { return get_user_seed(); }
 
 void interflop_prism_set_seed(uint64_t seed) { set_user_seed(seed); }
 
+void interflop_prism_set_rounding_mode(int32_t mode) {
+  prism::sr::set_rounding_mode(mode);
+}
+
+int32_t interflop_prism_get_rounding_mode(void) {
+  return prism::sr::rounding_mode;
+}
+
 } // extern "C"

--- a/src/prism_api.h
+++ b/src/prism_api.h
@@ -28,6 +28,13 @@ int32_t interflop_prism_get_default_virtual_precision_binary64(void);
 uint64_t interflop_prism_get_seed(void);
 void interflop_prism_set_seed(uint64_t seed);
 
+/* Rounding modes */
+#define INTERFLOP_PRISM_SR 0
+#define INTERFLOP_PRISM_RN 1
+
+void interflop_prism_set_rounding_mode(int32_t mode);
+int32_t interflop_prism_get_rounding_mode(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -56,7 +56,7 @@ template <typename T> auto isnumber(const T a, const T b) -> bool {
   return ret;
 }
 
-// Virtual Stochastic Rounding
+// Variable Precision Stochastic Rounding
 //
 // Based on the algorithm in Fasi and Mikaitis: Algorithms for Stochastically
 // Rounded Elementary Arithmetic Operations, originally implemented in Verrou,
@@ -69,23 +69,10 @@ template <typename T> auto isnumber(const T a, const T b) -> bool {
 //
 // The result is returned directly.
 //
-// Proof of exact sign evaluation for D = (rho - pi) + tau:
+// Proof of exact sign evaluation for D = (rho - pi) + tau available at:
 //
-// 1. |rho - pi| > |tau|
-//    In this case, (rho - pi) might suffer rounding error in float.
-//    However, since |tau| is bounded by 0.5 * ULP_hardware, and the
-//    distance to the zero-boundary is greater than |tau|, the rounding
-//    error cannot pull the result across zero. The boolean outcome of the
-//    sign check remains invariant to the rounding.
+//       https://github.com/user-attachments/files/29456845/vpsr.pdf
 //
-// 2. |rho - pi| <= |tau|
-//    Since |tau| <= 0.5 * ULP_hardware, and the minimum non-zero rho is
-//    1.0 * ULP_hardware, this condition restricts pi to the interval
-//    [0.5*rho, 1.5*rho] satisfying the Sterbenz Lemma. Thus, the subtraction
-//    (rho - pi) is exact.
-//
-//    (rho - pi) + tau can be inexact but we are only interested in its sign
-//    and IEEE-754 guarantees monotonic rounding.
 // ------------------------------------------------------------------------
 template <typename T> inline auto round(const T sigma, const T tau) -> T {
   const int32_t t = prism::sr::get_virtual_precision<T>();

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -123,7 +123,11 @@ template <typename T> inline auto round(const T sigma, const T tau) -> T {
   const T sc_ulp = ulp_t * scale;
 
   // We sample pi in Uniform(0, sc_ulp)
-  const T z = rng::uniform(T{});
+  // In SR mode, z is a random sample from Uniform(0, 1).
+  // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
+  const T z = (prism::sr::rounding_mode == prism::sr::PRISM_RN)
+                  ? T{0.5}
+                  : rng::uniform(T{});
   const T pi = sc_ulp * z;
 
   // We want to check if P < |x - trunc| where P = abs(pi).

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -601,8 +601,15 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   const auto sc_ulp = hn::Mul(ulp_t, scale);
 
   // We sample pi in Uniform(0, sc_ulp)
-  const auto z_rng = rng::uniform(T{});
-  const auto z = hn::ResizeBitCast(d, z_rng);
+  // In SR mode, z is a random sample from Uniform(0, 1).
+  // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
+  V z;
+  if (prism::sr::rounding_mode == prism::sr::PRISM_RN) {
+    z = hn::Set(d, T{0.5});
+  } else {
+    const auto z_rng = rng::uniform(T{});
+    z = hn::ResizeBitCast(d, z_rng);
+  }
   const auto pi = hn::Mul(sc_ulp, z);
 
   // We want to check if P < |x - trunc| where P = abs(pi).

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -488,7 +488,7 @@ HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
   return hn::BitCast(d, masked_bits);
 }
 
-// Virtual Stochastic Rounding (Vector)
+// Variable Precision Stochastic Rounding (Vector)
 //
 // Based on the algorithm in Fasi and Mikaitis: Algorithms for Stochastically
 // Rounded Elementary Arithmetic Operations, originally implemented in Verrou,
@@ -501,24 +501,10 @@ HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
 //
 // The result is returned directly.
 //
-// Proof of exact sign evaluation for D = (rho - pi) + tau:
+// Proof of exact sign evaluation for D = (rho - pi) + tau available at:
 //
-// 1. |rho - pi| > |tau|
-//    In this case, (rho - pi) might suffer rounding error in float.
-//    However, since |tau| is bounded by 0.5 * ULP_hardware, and the
-//    distance to the zero-boundary is greater than |tau|, the rounding
-//    error cannot pull the result across zero. The boolean outcome of the
-//    sign check remains invariant to the rounding.
+//       https://github.com/user-attachments/files/29456845/vpsr.pdf
 //
-// 2. |rho - pi| <= |tau|
-//    Since |tau| <= 0.5 * ULP_hardware, and the minimum non-zero rho is
-//    1.0 * ULP_hardware, this condition restricts pi to the interval
-//    [0.5*rho, 1.5*rho] satisfying the Sterbenz Lemma. Thus, the subtraction
-//    (rho - pi) is exact.
-//
-//    (rho - pi) + tau can be inexact but we are only interested in its sign
-//    and IEEE-754 guarantees monotonic rounding.
-// ------------------------------------------------------------------------
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   dbg::debug_msg("\n[sr_round] START");

--- a/src/utils.h
+++ b/src/utils.h
@@ -198,18 +198,26 @@ auto pow2_double(int64_t n) -> double;
 } // namespace prism::utils
 
 namespace prism::sr {
+// Rounding mode constants
+constexpr int32_t PRISM_SR = 0; // Stochastic Rounding
+constexpr int32_t PRISM_RN = 1; // Round-to-Nearest (untied, ties away from zero)
+
 // Process-wide defaults, set once before main() by vfcwrapper init.
 // Thread-local vars initialize from these so every new thread inherits them.
 inline int32_t default_virtual_precision_f32 = utils::IEEE754<float>::precision;
 inline int32_t default_virtual_precision_f64 =
     utils::IEEE754<double>::precision;
+inline int32_t default_rounding_mode = PRISM_SR;
 
 // Configurable virtual precision, default to hardware precision.
-// NOLINT
-inline thread_local int32_t virtual_precision_f32 = // NOLINT
+inline thread_local int32_t virtual_precision_f32 =
     default_virtual_precision_f32;
-inline thread_local int32_t virtual_precision_f64 = // NOLINT
+inline thread_local int32_t virtual_precision_f64 =
     default_virtual_precision_f64;
+
+// Configurable rounding mode, default to SR
+inline thread_local int32_t rounding_mode =
+    default_rounding_mode;
 
 template <typename T> inline auto get_virtual_precision() -> int32_t {
   if constexpr (std::is_same_v<T, float>) {
@@ -232,6 +240,13 @@ template <typename T> inline void set_virtual_precision(int32_t t) {
   } else {
     static_assert(!sizeof(T), "set_virtual_precision: unsupported type");
   }
+}
+
+inline auto get_rounding_mode() -> int32_t { return rounding_mode; }
+
+inline void set_rounding_mode(int32_t mode) {
+  assert(mode == PRISM_SR || mode == PRISM_RN);
+  rounding_mode = mode;
 }
 
 // Helper to mask off the lower bits of the mantissa to match a virtual

--- a/tests/scalar/BUILD
+++ b/tests/scalar/BUILD
@@ -23,6 +23,11 @@ cc_test_gen_scalar(
     name = "test_twoprodfma",
 )
 
+cc_test_gen_scalar(
+    name = "test_rn_mode",
+    mode = "dynamic",
+)
+
 # Accuracy tests
 
 # Stochastic Rounding rounding mode
@@ -131,6 +136,7 @@ test_suite(
         ":test_get_predabs",
         ":test_twoprodfma",
         ":test_twosum",
+        ":test_rn_mode",
         ":ud-accuracy",
     ],
 )

--- a/tests/scalar/test_rn_mode.cpp
+++ b/tests/scalar/test_rn_mode.cpp
@@ -1,0 +1,137 @@
+#include <cmath>
+#include <gtest/gtest.h>
+#include "src/prism_api.h"
+#include "src/sr_scalar.h"
+#include "src/utils.h"
+
+namespace srd = prism::sr::scalar::dynamic_dispatch;
+
+TEST(RNModeTest, BasicGetSet) {
+  // Test roundtrip of the rounding mode C API
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+  EXPECT_EQ(interflop_prism_get_rounding_mode(), INTERFLOP_PRISM_SR);
+
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+  EXPECT_EQ(interflop_prism_get_rounding_mode(), INTERFLOP_PRISM_RN);
+
+  // Revert to SR
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeTest, SpecialValues) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  // Special values on float
+  EXPECT_TRUE(std::isnan(srd::addf32(NAN, 1.0f)));
+  EXPECT_TRUE(std::isnan(srd::addf32(1.0f, NAN)));
+  EXPECT_TRUE(std::isinf(srd::addf32(INFINITY, 1.0f)));
+  EXPECT_EQ(srd::addf32(0.0f, 0.0f), 0.0f);
+  EXPECT_EQ(srd::addf32(-0.0f, -0.0f), -0.0f);
+
+  // Special values on double
+  EXPECT_TRUE(std::isnan(srd::addf64(NAN, 1.0)));
+  EXPECT_TRUE(std::isnan(srd::addf64(1.0, NAN)));
+  EXPECT_TRUE(std::isinf(srd::addf64(INFINITY, 1.0)));
+  EXPECT_EQ(srd::addf64(0.0, 0.0), 0.0);
+  EXPECT_EQ(srd::addf64(-0.0, -0.0), -0.0);
+
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeTest, NormalValuesPrecision) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  // Test float with virtual precision t = 10
+  prism::sr::set_virtual_precision<float>(10);
+  // ulp_t for 1.0f is 2^(-9) = 1.0f / 512.0f
+  float ulp_f = 1.0f / 512.0f;
+
+  // 1.0 + 0.3 * ulp should round to 1.0
+  EXPECT_EQ(srd::addf32(1.0f, 0.3f * ulp_f), 1.0f);
+  // 1.0 + 0.7 * ulp should round to 1.0 + ulp
+  EXPECT_EQ(srd::addf32(1.0f, 0.7f * ulp_f), 1.0f + ulp_f);
+  // 1.0 + 0.5 * ulp is a tie -> round away from zero (to 1.0 + ulp)
+  EXPECT_EQ(srd::addf32(1.0f, 0.5f * ulp_f), 1.0f + ulp_f);
+
+  // Test double with virtual precision t = 15
+  prism::sr::set_virtual_precision<double>(15);
+  // ulp_t for 1.0 is 2^(-14) = 1.0 / 16384.0
+  double ulp_d = 1.0 / 16384.0;
+
+  // 1.0 + 0.3 * ulp should round to 1.0
+  EXPECT_EQ(srd::addf64(1.0, 0.3 * ulp_d), 1.0);
+  // 1.0 + 0.7 * ulp should round to 1.0 + ulp
+  EXPECT_EQ(srd::addf64(1.0, 0.7 * ulp_d), 1.0 + ulp_d);
+  // 1.0 + 0.5 * ulp is a tie -> round away from zero (to 1.0 + ulp)
+  EXPECT_EQ(srd::addf64(1.0, 0.5 * ulp_d), 1.0 + ulp_d);
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeTest, TiesRoundingAwayFromZero) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  // Test both float and double with different virtual precisions
+  for (int t = 5; t <= 20; ++t) {
+    prism::sr::set_virtual_precision<float>(t);
+    float ulp_f = std::pow(2.0f, -(t - 1));
+
+    // Positive tie: rounds away from zero (up)
+    EXPECT_EQ(srd::addf32(1.0f, 0.5f * ulp_f), 1.0f + ulp_f);
+    // Negative tie: rounds away from zero (down/larger magnitude)
+    EXPECT_EQ(srd::addf32(-1.0f, -0.5f * ulp_f), -1.0f - ulp_f);
+  }
+
+  for (int t = 5; t <= 40; ++t) {
+    prism::sr::set_virtual_precision<double>(t);
+    double ulp_d = std::pow(2.0, -(t - 1));
+
+    // Positive tie: rounds away from zero (up)
+    EXPECT_EQ(srd::addf64(1.0, 0.5 * ulp_d), 1.0 + ulp_d);
+    // Negative tie: rounds away from zero (down/larger magnitude)
+    EXPECT_EQ(srd::addf64(-1.0, -0.5 * ulp_d), -1.0 - ulp_d);
+  }
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeTest, SubnormalValues) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  // For float virtual subnormals at t = 10
+  prism::sr::set_virtual_precision<float>(10);
+  // virtual subnormal ulp at t=10 is 2^(-126 - 9) = 2^(-135)
+  float ulp_sub_f = std::pow(2.0f, -135.0f);
+
+  // Tie on virtual subnormal: rounds away from zero
+  EXPECT_EQ(srd::addf32(ulp_sub_f, 0.5f * ulp_sub_f), 2.0f * ulp_sub_f);
+  EXPECT_EQ(srd::addf32(-ulp_sub_f, -0.5f * ulp_sub_f), -2.0f * ulp_sub_f);
+
+  // Normal rounding for virtual subnormals
+  EXPECT_EQ(srd::addf32(ulp_sub_f, 0.3f * ulp_sub_f), ulp_sub_f);
+  EXPECT_EQ(srd::addf32(ulp_sub_f, 0.7f * ulp_sub_f), 2.0f * ulp_sub_f);
+
+  // For double virtual subnormals at t = 20
+  prism::sr::set_virtual_precision<double>(20);
+  // virtual subnormal ulp at t=20 is 2^(-1022 - 19) = 2^(-1041)
+  double ulp_sub_d = std::pow(2.0, -1041.0);
+
+  // Tie on virtual subnormal: rounds away from zero
+  EXPECT_EQ(srd::addf64(ulp_sub_d, 0.5 * ulp_sub_d), 2.0 * ulp_sub_d);
+  EXPECT_EQ(srd::addf64(-ulp_sub_d, -0.5 * ulp_sub_d), -2.0 * ulp_sub_d);
+
+  // Normal rounding for virtual subnormals
+  EXPECT_EQ(srd::addf64(ulp_sub_d, 0.3 * ulp_sub_d), ulp_sub_d);
+  EXPECT_EQ(srd::addf64(ulp_sub_d, 0.7 * ulp_sub_d), 2.0 * ulp_sub_d);
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}

--- a/tests/vector/BUILD
+++ b/tests/vector/BUILD
@@ -13,6 +13,11 @@ cc_test_gen_vector(
 )
 
 cc_test_gen_vector(
+    name = "test_rn_mode",
+    mode = "dynamic",
+)
+
+cc_test_gen_vector(
     name = "test_get_exponent",
     dbg = True,
 )
@@ -228,6 +233,7 @@ test_suite(
         ":test_split",
         ":test_splitbit",
         ":test_twosum",
+        ":test_rn_mode",
         ":thread",
         ":thread-static",
         ":ud-accuracy",

--- a/tests/vector/test_rn_mode.cpp
+++ b/tests/vector/test_rn_mode.cpp
@@ -1,0 +1,169 @@
+#include <cmath>
+#include <vector>
+#include <gtest/gtest.h>
+#include "src/prism_api.h"
+#include "src/sr_vector.h"
+#include "src/utils.h"
+
+namespace vrv = prism::sr::vector::dynamic_dispatch::variable;
+
+TEST(RNModeVectorTest, SpecialValues) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  constexpr size_t count = 5;
+  std::vector<float> a_f = {NAN, 1.0f, INFINITY, 0.0f, -0.0f};
+  std::vector<float> b_f = {1.0f, NAN, 1.0f, 0.0f, -0.0f};
+  std::vector<float> res_f(count);
+
+  vrv::addf32(a_f.data(), b_f.data(), res_f.data(), count);
+
+  EXPECT_TRUE(std::isnan(res_f[0]));
+  EXPECT_TRUE(std::isnan(res_f[1]));
+  EXPECT_TRUE(std::isinf(res_f[2]));
+  EXPECT_EQ(res_f[3], 0.0f);
+  EXPECT_EQ(res_f[4], -0.0f);
+
+  std::vector<double> a_d = {NAN, 1.0, INFINITY, 0.0, -0.0};
+  std::vector<double> b_d = {1.0, NAN, 1.0, 0.0, -0.0};
+  std::vector<double> res_d(count);
+
+  vrv::addf64(a_d.data(), b_d.data(), res_d.data(), count);
+
+  EXPECT_TRUE(std::isnan(res_d[0]));
+  EXPECT_TRUE(std::isnan(res_d[1]));
+  EXPECT_TRUE(std::isinf(res_d[2]));
+  EXPECT_EQ(res_d[3], 0.0);
+  EXPECT_EQ(res_d[4], -0.0);
+
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeVectorTest, NormalValuesPrecision) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  // Test float with virtual precision t = 10
+  prism::sr::set_virtual_precision<float>(10);
+  float ulp_f = 1.0f / 512.0f;
+
+  constexpr size_t count = 3;
+  std::vector<float> a_f(count, 1.0f);
+  std::vector<float> b_f = {0.3f * ulp_f, 0.7f * ulp_f, 0.5f * ulp_f};
+  std::vector<float> res_f(count);
+
+  vrv::addf32(a_f.data(), b_f.data(), res_f.data(), count);
+
+  // 1.0 + 0.3 * ulp -> 1.0
+  EXPECT_EQ(res_f[0], 1.0f);
+  // 1.0 + 0.7 * ulp -> 1.0 + ulp
+  EXPECT_EQ(res_f[1], 1.0f + ulp_f);
+  // 1.0 + 0.5 * ulp is a tie -> rounds away from zero (to 1.0 + ulp)
+  EXPECT_EQ(res_f[2], 1.0f + ulp_f);
+
+  // Test double with virtual precision t = 15
+  prism::sr::set_virtual_precision<double>(15);
+  double ulp_d = 1.0 / 16384.0;
+
+  std::vector<double> a_d(count, 1.0);
+  std::vector<double> b_d = {0.3 * ulp_d, 0.7 * ulp_d, 0.5 * ulp_d};
+  std::vector<double> res_d(count);
+
+  vrv::addf64(a_d.data(), b_d.data(), res_d.data(), count);
+
+  // 1.0 + 0.3 * ulp -> 1.0
+  EXPECT_EQ(res_d[0], 1.0);
+  // 1.0 + 0.7 * ulp -> 1.0 + ulp
+  EXPECT_EQ(res_d[1], 1.0 + ulp_d);
+  // 1.0 + 0.5 * ulp is a tie -> rounds away from zero (to 1.0 + ulp)
+  EXPECT_EQ(res_d[2], 1.0 + ulp_d);
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeVectorTest, TiesRoundingAwayFromZero) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  constexpr size_t count = 2;
+
+  // Test float with different virtual precisions
+  for (int t = 5; t <= 20; ++t) {
+    prism::sr::set_virtual_precision<float>(t);
+    float ulp_f = std::pow(2.0f, -(t - 1));
+
+    std::vector<float> a_f = {1.0f, -1.0f};
+    std::vector<float> b_f = {0.5f * ulp_f, -0.5f * ulp_f};
+    std::vector<float> res_f(count);
+
+    vrv::addf32(a_f.data(), b_f.data(), res_f.data(), count);
+
+    // Positive tie: rounds away from zero (up)
+    EXPECT_EQ(res_f[0], 1.0f + ulp_f);
+    // Negative tie: rounds away from zero (down)
+    EXPECT_EQ(res_f[1], -1.0f - ulp_f);
+  }
+
+  // Test double with different virtual precisions
+  for (int t = 5; t <= 40; ++t) {
+    prism::sr::set_virtual_precision<double>(t);
+    double ulp_d = std::pow(2.0, -(t - 1));
+
+    std::vector<double> a_d = {1.0, -1.0};
+    std::vector<double> b_d = {0.5 * ulp_d, -0.5 * ulp_d};
+    std::vector<double> res_d(count);
+
+    vrv::addf64(a_d.data(), b_d.data(), res_d.data(), count);
+
+    // Positive tie: rounds away from zero (up)
+    EXPECT_EQ(res_d[0], 1.0 + ulp_d);
+    // Negative tie: rounds away from zero (down)
+    EXPECT_EQ(res_d[1], -1.0 - ulp_d);
+  }
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}
+
+TEST(RNModeVectorTest, SubnormalValues) {
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+
+  constexpr size_t count = 4;
+
+  // Float virtual subnormals at t = 10
+  prism::sr::set_virtual_precision<float>(10);
+  float ulp_sub_f = std::pow(2.0f, -135.0f);
+
+  std::vector<float> a_f = {ulp_sub_f, -ulp_sub_f, ulp_sub_f, ulp_sub_f};
+  std::vector<float> b_f = {0.5f * ulp_sub_f, -0.5f * ulp_sub_f, 0.3f * ulp_sub_f, 0.7f * ulp_sub_f};
+  std::vector<float> res_f(count);
+
+  vrv::addf32(a_f.data(), b_f.data(), res_f.data(), count);
+
+  EXPECT_EQ(res_f[0], 2.0f * ulp_sub_f);
+  EXPECT_EQ(res_f[1], -2.0f * ulp_sub_f);
+  EXPECT_EQ(res_f[2], ulp_sub_f);
+  EXPECT_EQ(res_f[3], 2.0f * ulp_sub_f);
+
+  // Double virtual subnormals at t = 20
+  prism::sr::set_virtual_precision<double>(20);
+  double ulp_sub_d = std::pow(2.0, -1041.0);
+
+  std::vector<double> a_d = {ulp_sub_d, -ulp_sub_d, ulp_sub_d, ulp_sub_d};
+  std::vector<double> b_d = {0.5 * ulp_sub_d, -0.5 * ulp_sub_d, 0.3 * ulp_sub_d, 0.7 * ulp_sub_d};
+  std::vector<double> res_d(count);
+
+  vrv::addf64(a_d.data(), b_d.data(), res_d.data(), count);
+
+  EXPECT_EQ(res_d[0], 2.0 * ulp_sub_d);
+  EXPECT_EQ(res_d[1], -2.0 * ulp_sub_d);
+  EXPECT_EQ(res_d[2], ulp_sub_d);
+  EXPECT_EQ(res_d[3], 2.0 * ulp_sub_d);
+
+  // Clean up
+  prism::sr::set_virtual_precision<float>(24);
+  prism::sr::set_virtual_precision<double>(53);
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+}


### PR DESCRIPTION
By setting z = rng::uniform() sample to 0.5; we get an untied round-to-nearest (tie away from zero) mode.
This PR implements such a mode and adds some tests.

During design a compromise arose:
- we can achieve zero-hit performance by using a compile-time template to select between rng::uniform() and 0.5; yet this implies that the rounding mode is set once and for all at the beginning;
- we can allow changing the rounding mode dynamically, which I would like to do in our LLM explorations, but this requires an IF branch.

In the end I decided to implement the IF branch since its overhead cost should be very low, we will pay the branch miss-prediction only the first time after a change of mode. Later the branch should be well predicted and have little overhead.

