### PR TITLE
Make precision and rounding-mode changes reach running threads

### DIFF
--- a/src/generic_vector-inl.h
+++ b/src/generic_vector-inl.h
@@ -44,13 +44,14 @@ HWY_FLATTEN void _round(const T *HWY_RESTRICT sigma, const T *HWY_RESTRICT tau,
   using D = hn::ScalableTag<T>;
   const D d{};
   const size_t N = hn::Lanes(d);
+  const auto config = prism::sr::get_config_snapshot<T>();
 
   for (size_t i = 0; i < count; i += N) {
     const size_t remaining = count - i;
     const size_t lanes = remaining < N ? remaining : N;
     auto sigma_vec = hn::LoadN(d, sigma + i, lanes);
     auto tau_vec = hn::LoadN(d, tau + i, lanes);
-    auto res = pr::round(d, sigma_vec, tau_vec);
+    auto res = pr::round(d, sigma_vec, tau_vec, config);
     hn::StoreN(res, d, result + i, lanes);
   }
 }

--- a/src/prism_api.cpp
+++ b/src/prism_api.cpp
@@ -17,19 +17,37 @@
 extern "C" {
 
 void interflop_prism_set_default_virtual_precision_binary32(int32_t t) {
-  prism::sr::default_virtual_precision_f32 = t;
+  prism::sr::set_default_virtual_precision<float>(t);
 }
 
 void interflop_prism_set_default_virtual_precision_binary64(int32_t t) {
-  prism::sr::default_virtual_precision_f64 = t;
+  prism::sr::set_default_virtual_precision<double>(t);
 }
 
 int32_t interflop_prism_get_default_virtual_precision_binary32(void) {
-  return prism::sr::default_virtual_precision_f32;
+  return prism::sr::default_virtual_precision_f32.load(
+      std::memory_order_relaxed);
 }
 
 int32_t interflop_prism_get_default_virtual_precision_binary64(void) {
-  return prism::sr::default_virtual_precision_f64;
+  return prism::sr::default_virtual_precision_f64.load(
+      std::memory_order_relaxed);
+}
+
+int32_t interflop_prism_get_virtual_precision_binary32(void) {
+  return prism::sr::get_virtual_precision<float>();
+}
+
+int32_t interflop_prism_get_virtual_precision_binary64(void) {
+  return prism::sr::get_virtual_precision<double>();
+}
+
+void interflop_prism_set_thread_virtual_precision_binary32(int32_t t) {
+  prism::sr::set_virtual_precision<float>(t);
+}
+
+void interflop_prism_set_thread_virtual_precision_binary64(int32_t t) {
+  prism::sr::set_virtual_precision<double>(t);
 }
 
 uint64_t interflop_prism_get_seed(void) { return get_user_seed(); }
@@ -37,11 +55,15 @@ uint64_t interflop_prism_get_seed(void) { return get_user_seed(); }
 void interflop_prism_set_seed(uint64_t seed) { set_user_seed(seed); }
 
 void interflop_prism_set_rounding_mode(int32_t mode) {
-  prism::sr::set_rounding_mode(mode);
+  prism::sr::set_default_rounding_mode(mode);
 }
 
 int32_t interflop_prism_get_rounding_mode(void) {
-  return prism::sr::rounding_mode;
+  return prism::sr::get_rounding_mode();
+}
+
+void interflop_prism_set_thread_rounding_mode(int32_t mode) {
+  prism::sr::set_rounding_mode(mode);
 }
 
 } // extern "C"

--- a/src/prism_api.h
+++ b/src/prism_api.h
@@ -19,11 +19,23 @@
 extern "C" {
 #endif
 
+/* Process-wide setters: the new value reaches every thread, including threads
+ * that have already executed instrumented arithmetic, on their next operation.
+ * A process-wide set discards any outstanding per-thread override. */
 void interflop_prism_set_default_virtual_precision_binary32(int32_t t);
 void interflop_prism_set_default_virtual_precision_binary64(int32_t t);
 
 int32_t interflop_prism_get_default_virtual_precision_binary32(void);
 int32_t interflop_prism_get_default_virtual_precision_binary64(void);
+
+/* Precision the calling thread will actually round at. Use this, not the
+ * default getter, to check that a setting took effect. */
+int32_t interflop_prism_get_virtual_precision_binary32(void);
+int32_t interflop_prism_get_virtual_precision_binary64(void);
+
+/* Per-thread override, in effect until the next process-wide set. */
+void interflop_prism_set_thread_virtual_precision_binary32(int32_t t);
+void interflop_prism_set_thread_virtual_precision_binary64(int32_t t);
 
 uint64_t interflop_prism_get_seed(void);
 void interflop_prism_set_seed(uint64_t seed);
@@ -32,8 +44,12 @@ void interflop_prism_set_seed(uint64_t seed);
 #define INTERFLOP_PRISM_SR 0
 #define INTERFLOP_PRISM_RN 1
 
+/* Process-wide, like the precision setter above. */
 void interflop_prism_set_rounding_mode(int32_t mode);
+/* Mode the calling thread will actually round with. */
 int32_t interflop_prism_get_rounding_mode(void);
+/* Per-thread override, in effect until the next process-wide set. */
+void interflop_prism_set_thread_rounding_mode(int32_t mode);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -125,7 +125,7 @@ template <typename T> inline auto round(const T sigma, const T tau) -> T {
   // We sample pi in Uniform(0, sc_ulp)
   // In SR mode, z is a random sample from Uniform(0, 1).
   // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
-  const T z = (prism::sr::rounding_mode == prism::sr::PRISM_RN)
+  const T z = (prism::sr::get_rounding_mode() == prism::sr::PRISM_RN)
                   ? T{0.5}
                   : rng::uniform(T{});
   const T pi = sc_ulp * z;

--- a/src/sr_scalar-inl.h
+++ b/src/sr_scalar-inl.h
@@ -26,7 +26,9 @@ namespace prism::sr::scalar::HWY_NAMESPACE {
 
 namespace rng = prism::scalar::xoshiro::HWY_NAMESPACE;
 
-template <typename T> auto isnumber(const T a, const T b) -> bool {
+template <typename T>
+auto isnumber(const T a, const T b,
+              const prism::sr::ConfigSnapshot &config) -> bool {
   using U = typename prism::utils::IEEE754<T>::U;
   debug_start();
   constexpr auto naninf_mask = prism::utils::IEEE754<T>::inf_nan_mask;
@@ -36,7 +38,7 @@ template <typename T> auto isnumber(const T a, const T b) -> bool {
   const U a_uint = a_bits.u;
   const U b_uint = b_bits.u;
 
-  const int32_t t = prism::sr::get_virtual_precision<T>();
+  const int32_t t = config.virtual_precision;
   bool ret = false;
   if ((t - 1) < mantissa) {
     // At reduced virtual precision, zero operands can produce results
@@ -74,8 +76,10 @@ template <typename T> auto isnumber(const T a, const T b) -> bool {
 //       https://github.com/user-attachments/files/29456845/vpsr.pdf
 //
 // ------------------------------------------------------------------------
-template <typename T> inline auto round(const T sigma, const T tau) -> T {
-  const int32_t t = prism::sr::get_virtual_precision<T>();
+template <typename T>
+inline auto round(const T sigma, const T tau,
+                  const prism::sr::ConfigSnapshot &config) -> T {
+  const int32_t t = config.virtual_precision;
   using prism::utils::get_exponent;
   using prism::utils::get_predecessor_abs;
   using prism::utils::IEEE754;
@@ -125,9 +129,8 @@ template <typename T> inline auto round(const T sigma, const T tau) -> T {
   // We sample pi in Uniform(0, sc_ulp)
   // In SR mode, z is a random sample from Uniform(0, 1).
   // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
-  const T z = (prism::sr::get_rounding_mode() == prism::sr::PRISM_RN)
-                  ? T{0.5}
-                  : rng::uniform(T{});
+  const T z = (config.rounding_mode == prism::sr::PRISM_RN) ? T{0.5}
+                                                            : rng::uniform(T{});
   const T pi = sc_ulp * z;
 
   // We want to check if P < |x - trunc| where P = abs(pi).
@@ -151,15 +154,16 @@ template <typename T> inline auto round(const T sigma, const T tau) -> T {
 }
 
 template <typename T> inline auto add(const T a, const T b) -> T {
+  const auto config = prism::sr::get_config_snapshot<T>();
   debug_start();
-  if (not isnumber(a, b)) {
+  if (not isnumber(a, b, config)) {
     debug_end();
     return a + b;
   }
   T tau;
   T sigma;
   twosum(a, b, sigma, tau);
-  const T res = round(sigma, tau);
+  const T res = round(sigma, tau, config);
   debug_print("sr_add(%+.13a, %+.13a) = %+.13a\n", a, b, res);
   debug_end();
   return res;
@@ -168,22 +172,24 @@ template <typename T> inline auto add(const T a, const T b) -> T {
 template <typename T> inline auto sub(T a, T b) -> T { return add(a, -b); }
 
 template <typename T> inline auto mul(T a, T b) -> T {
+  const auto config = prism::sr::get_config_snapshot<T>();
   debug_start();
-  if (not isnumber(a, b)) {
+  if (not isnumber(a, b, config)) {
     debug_end();
     return a * b;
   }
   T tau;
   T sigma;
   twoprodfma(a, b, sigma, tau);
-  const T res = round(sigma, tau);
+  const T res = round(sigma, tau, config);
   debug_end();
   return res;
 }
 
 template <typename T> inline auto div(const T a, const T b) -> T {
+  const auto config = prism::sr::get_config_snapshot<T>();
   debug_start();
-  if (not isnumber(a, b)) {
+  if (not isnumber(a, b, config)) {
     debug_end();
     return a / b;
   }
@@ -196,20 +202,21 @@ template <typename T> inline auto div(const T a, const T b) -> T {
               a, std::fma(-sigma, b, a));
   debug_print("tau = (-%+.13a * %+.13a + %+.13a) / %+.13a\n", -sigma, b, a, b);
 
-  const T res = round(sigma, tau);
+  const T res = round(sigma, tau, config);
   debug_print("sr_div(%+.13a, %+.13a) = %+.13a\n", a, b, res);
   debug_end();
   return res;
 }
 
 template <typename T> inline auto sqrt(const T a) -> T {
+  const auto config = prism::sr::get_config_snapshot<T>();
   const T sigma = std::sqrt(a);
   if (not std::isfinite(a) or a <= 0) {
     return sigma;
   }
   const T tau_p = std::fma(-sigma, sigma, a);
   const T tau = tau_p / (2 * sigma);
-  return round(sigma, tau);
+  return round(sigma, tau, config);
 }
 
 /*
@@ -225,6 +232,7 @@ Algorithm 5 (ErrFmaNearest):
   r2 = ◦(γ + α2)
 */
 template <typename T> inline auto fma(const T a, const T b, const T c) -> T {
+  const auto config = prism::sr::get_config_snapshot<T>();
   if (not std::isfinite(a) or not std::isfinite(b) or not std::isfinite(c)) {
     return std::fma(a, b, c);
   }
@@ -244,7 +252,7 @@ template <typename T> inline auto fma(const T a, const T b, const T c) -> T {
   twosum(u1, alpha1, beta1, beta2);
   gamma = (beta1 - r1) + beta2;
   r2 = gamma + alpha2;
-  const T res = round(r1, r2);
+  const T res = round(r1, r2, config);
   debug_print("sr_fma(%+.13a, %+.13a, %+.13a) = %+.13a\n", a, b, c, res);
   debug_end();
   return res;

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -604,7 +604,7 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   // In SR mode, z is a random sample from Uniform(0, 1).
   // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
   V z;
-  if (prism::sr::rounding_mode == prism::sr::PRISM_RN) {
+  if (prism::sr::get_rounding_mode() == prism::sr::PRISM_RN) {
     z = hn::Set(d, T{0.5});
   } else {
     const auto z_rng = rng::uniform(T{});

--- a/src/sr_vector-inl.h
+++ b/src/sr_vector-inl.h
@@ -468,8 +468,8 @@ HWY_INLINE auto pow2(const D d, const VI n) -> hn::VFromD<D> {
 }
 
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
-HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
-  const int32_t t = prism::sr::get_virtual_precision<T>();
+HWY_INLINE auto truncate_mantissa(const D d, const V val,
+                                  const int32_t t) -> V {
   constexpr int32_t mantissa = prism::utils::IEEE754<T>::mantissa;
 
   if (HWY_UNLIKELY((t - 1) >= mantissa))
@@ -506,18 +506,19 @@ HWY_INLINE auto truncate_mantissa(const D d, const V val) -> V {
 //       https://github.com/user-attachments/files/29456845/vpsr.pdf
 //
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
-HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
+HWY_FLATTEN auto round(const D d, const V sigma, const V tau,
+                       const prism::sr::ConfigSnapshot &config) -> V {
   dbg::debug_msg("\n[sr_round] START");
   dbg::debug_vec(d, "[sr_round] σ", sigma);
   dbg::debug_vec(d, "[sr_round] τ", tau);
 
-  const int32_t t = prism::sr::get_virtual_precision<T>();
+  const int32_t t = config.virtual_precision;
   const auto zero = hn::Zero(d);
   const auto one = hn::Set(d, T{1});
   const auto neg_one = hn::Set(d, T{-1});
 
   // compute trunc_t(sigma), the truncated value at precision t
-  const auto trunc = truncate_mantissa(d, sigma);
+  const auto trunc = truncate_mantissa(d, sigma, t);
 
   // rho is the distance from sigma to trunc
   // the computation is exact in IEEE-754
@@ -604,7 +605,7 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
   // In SR mode, z is a random sample from Uniform(0, 1).
   // In RN mode, z = 0.5 gives untied round-to-nearest (ties away from zero).
   V z;
-  if (prism::sr::get_rounding_mode() == prism::sr::PRISM_RN) {
+  if (config.rounding_mode == prism::sr::PRISM_RN) {
     z = hn::Set(d, T{0.5});
   } else {
     const auto z_rng = rng::uniform(T{});
@@ -636,11 +637,12 @@ HWY_FLATTEN auto round(const D d, const V sigma, const V tau) -> V {
 
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto add(const D d, const V a, const V b) -> V {
+  const auto config = prism::sr::get_config_snapshot<T>();
   dbg::debug_msg("\n[sr_add] START");
   V sigma;
   V tau;
   twosum(d, a, b, sigma, tau);
-  const auto ret = round(d, sigma, tau);
+  const auto ret = round(d, sigma, tau, config);
   dbg::debug_vec(d, "[sr_add] res", ret);
   dbg::debug_msg("[sr_add] END\n");
   return ret;
@@ -657,11 +659,12 @@ HWY_FLATTEN auto sub(const D d, const V a, const V b) -> V {
 
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto mul(const D d, const V a, const V b) -> V {
+  const auto config = prism::sr::get_config_snapshot<T>();
   dbg::debug_msg("\n[sr_add] START");
   V sigma;
   V tau;
   twoprodfma(d, a, b, sigma, tau);
-  const auto ret = round(d, sigma, tau);
+  const auto ret = round(d, sigma, tau, config);
   dbg::debug_vec(d, "[sr_mul] res", ret);
   dbg::debug_msg("[sr_mul] END\n");
 
@@ -684,6 +687,7 @@ the Change of the Rounding Mode
 */
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto div(const D d, const V a, const V b) -> V {
+  const auto config = prism::sr::get_config_snapshot<T>();
   dbg::debug_msg("\n[sr_div] START");
   dbg::debug_vec(d, "[sr_div] a", a);
   dbg::debug_vec(d, "[sr_div] b", b);
@@ -701,7 +705,7 @@ HWY_FLATTEN auto div(const D d, const V a, const V b) -> V {
   dbg::debug_vec(d, "[sr_div] τ'", tau_p);
   const auto tau = hn::Div(tau_p, b);
   dbg::debug_vec(d, "[sr_div] τ", tau);
-  const auto ret = round(d, sigma, tau);
+  const auto ret = round(d, sigma, tau, config);
   dbg::debug_vec(d, "[sr_div] res", ret);
   dbg::debug_msg("[sr_div] END\n");
 
@@ -710,6 +714,7 @@ HWY_FLATTEN auto div(const D d, const V a, const V b) -> V {
 
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto sqrt(const D d, const V a) -> V {
+  const auto config = prism::sr::get_config_snapshot<T>();
   dbg::debug_msg("\n[sr_sqrt] START");
   const auto sigma = hn::Sqrt(a);
   // -sigma * sigma + a
@@ -717,7 +722,7 @@ HWY_FLATTEN auto sqrt(const D d, const V a) -> V {
   const auto _div = hn::Div(tau_p, sigma);
   const auto half = hn::Set(d, 0.5);
   const auto tau = hn::Mul(half, _div);
-  const auto ret = round(d, sigma, tau);
+  const auto ret = round(d, sigma, tau, config);
   dbg::debug_vec(d, "[sr_sqrt] res", ret);
   dbg::debug_msg("[sr_sqrt] END\n");
 
@@ -738,6 +743,7 @@ Algorithm 5 (ErrFmaNearest):
 */
 template <class D, class V = hn::VFromD<D>, typename T = hn::TFromD<D>>
 HWY_FLATTEN auto fma(const D d, const V a, const V b, const V c) -> V {
+  const auto config = prism::sr::get_config_snapshot<T>();
   dbg::debug_msg("\n[sr_fma] START");
   dbg::debug_vec(d, "[sr_fma] a", a);
   dbg::debug_vec(d, "[sr_fma] b", b);
@@ -764,7 +770,7 @@ HWY_FLATTEN auto fma(const D d, const V a, const V b, const V c) -> V {
   const auto beta1_sub_r1 = hn::Sub(beta1, r1);
   gamma = hn::Add(beta1_sub_r1, beta2);
   r2 = hn::Add(gamma, alpha2);
-  const auto res = round(d, r1, r2);
+  const auto res = round(d, r1, r2, config);
   dbg::debug_vec(d, "[sr_fma] res", res);
   dbg::debug_msg("[sr_fma] END\n");
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,7 @@
 #ifndef __PRISM_UTILS_H__
 #define __PRISM_UTILS_H__
 
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -202,24 +203,60 @@ namespace prism::sr {
 constexpr int32_t PRISM_SR = 0; // Stochastic Rounding
 constexpr int32_t PRISM_RN = 1; // Round-to-Nearest (untied, ties away from zero)
 
-// Process-wide defaults, set once before main() by vfcwrapper init.
-// Thread-local vars initialize from these so every new thread inherits them.
-inline int32_t default_virtual_precision_f32 = utils::IEEE754<float>::precision;
-inline int32_t default_virtual_precision_f64 =
-    utils::IEEE754<double>::precision;
-inline int32_t default_rounding_mode = PRISM_SR;
+// Process-wide configuration.
+//
+// Virtual precision and rounding mode are kept thread-locally so that threads
+// may round independently, but they are *set* process-wide: a caller changing
+// precision between two phases of a computation means it for every thread, not
+// only its own. A thread cannot be written to from outside, so the two are
+// reconciled by an epoch. Every process-wide setter publishes new defaults and
+// bumps the epoch; a thread compares the epoch against the one it last observed
+// and refreshes its copy when they differ. The check costs one relaxed load per
+// kernel invocation -- get_virtual_precision() and get_rounding_mode() are
+// called once per operation, not once per element.
+//
+// Without this, a setter is a silent no-op for any thread that has already
+// executed instrumented arithmetic: the thread copied the default on first use
+// and never looks at it again, while the getter keeps reporting the new value.
+inline std::atomic<int32_t> default_virtual_precision_f32{
+    utils::IEEE754<float>::precision};
+inline std::atomic<int32_t> default_virtual_precision_f64{
+    utils::IEEE754<double>::precision};
+inline std::atomic<int32_t> default_rounding_mode{PRISM_SR};
 
-// Configurable virtual precision, default to hardware precision.
+// Bumped by every process-wide setter. Release/acquire pairing with the
+// defaults above: a thread that sees a new epoch also sees the values that
+// were published before it.
+inline std::atomic<uint32_t> config_epoch{0};
+
+// Per-thread configuration. The initializers cover threads created before the
+// first setter runs; every later change arrives through the epoch.
 inline thread_local int32_t virtual_precision_f32 =
-    default_virtual_precision_f32;
+    default_virtual_precision_f32.load(std::memory_order_relaxed);
 inline thread_local int32_t virtual_precision_f64 =
-    default_virtual_precision_f64;
-
-// Configurable rounding mode, default to SR
+    default_virtual_precision_f64.load(std::memory_order_relaxed);
 inline thread_local int32_t rounding_mode =
-    default_rounding_mode;
+    default_rounding_mode.load(std::memory_order_relaxed);
+inline thread_local uint32_t observed_epoch = 0;
+
+// Adopts the process-wide configuration if it changed since this thread last
+// looked. All three settings refresh together, so a kernel cannot mix a
+// precision from one epoch with a rounding mode from another.
+inline void refresh_thread_config() {
+  const uint32_t epoch = config_epoch.load(std::memory_order_acquire);
+  if (epoch == observed_epoch) {
+    return;
+  }
+  virtual_precision_f32 =
+      default_virtual_precision_f32.load(std::memory_order_relaxed);
+  virtual_precision_f64 =
+      default_virtual_precision_f64.load(std::memory_order_relaxed);
+  rounding_mode = default_rounding_mode.load(std::memory_order_relaxed);
+  observed_epoch = epoch;
+}
 
 template <typename T> inline auto get_virtual_precision() -> int32_t {
+  refresh_thread_config();
   if constexpr (std::is_same_v<T, float>) {
     return virtual_precision_f32;
   } else if constexpr (std::is_same_v<T, double>) {
@@ -229,10 +266,18 @@ template <typename T> inline auto get_virtual_precision() -> int32_t {
   }
 }
 
+inline auto get_rounding_mode() -> int32_t {
+  refresh_thread_config();
+  return rounding_mode;
+}
+
+// Thread-local override. Stamps the current epoch so the value survives until
+// the next process-wide setter, which discards it.
 template <typename T> inline void set_virtual_precision(int32_t t) {
   constexpr int32_t precision = prism::utils::IEEE754<T>::mantissa + 1;
   assert(t >= 2 && t <= precision);
 
+  refresh_thread_config();
   if constexpr (std::is_same_v<T, float>) {
     virtual_precision_f32 = t;
   } else if constexpr (std::is_same_v<T, double>) {
@@ -242,11 +287,32 @@ template <typename T> inline void set_virtual_precision(int32_t t) {
   }
 }
 
-inline auto get_rounding_mode() -> int32_t { return rounding_mode; }
-
 inline void set_rounding_mode(int32_t mode) {
   assert(mode == PRISM_SR || mode == PRISM_RN);
+  refresh_thread_config();
   rounding_mode = mode;
+}
+
+// Process-wide setters. Publish the new value, then bump the epoch so every
+// other thread picks it up on its next operation.
+template <typename T> inline void set_default_virtual_precision(int32_t t) {
+  constexpr int32_t precision = prism::utils::IEEE754<T>::mantissa + 1;
+  assert(t >= 2 && t <= precision);
+
+  if constexpr (std::is_same_v<T, float>) {
+    default_virtual_precision_f32.store(t, std::memory_order_relaxed);
+  } else if constexpr (std::is_same_v<T, double>) {
+    default_virtual_precision_f64.store(t, std::memory_order_relaxed);
+  } else {
+    static_assert(!sizeof(T), "set_default_virtual_precision: unsupported type");
+  }
+  config_epoch.fetch_add(1, std::memory_order_release);
+}
+
+inline void set_default_rounding_mode(int32_t mode) {
+  assert(mode == PRISM_SR || mode == PRISM_RN);
+  default_rounding_mode.store(mode, std::memory_order_relaxed);
+  config_epoch.fetch_add(1, std::memory_order_release);
 }
 
 // Helper to mask off the lower bits of the mantissa to match a virtual

--- a/src/utils.h
+++ b/src/utils.h
@@ -211,9 +211,10 @@ constexpr int32_t PRISM_RN = 1; // Round-to-Nearest (untied, ties away from zero
 // only its own. A thread cannot be written to from outside, so the two are
 // reconciled by an epoch. Every process-wide setter publishes new defaults and
 // bumps the epoch; a thread compares the epoch against the one it last observed
-// and refreshes its copy when they differ. The check costs one relaxed load per
-// kernel invocation -- get_virtual_precision() and get_rounding_mode() are
-// called once per operation, not once per element.
+// and refreshes its copy when they differ. Each arithmetic operation captures
+// one configuration snapshot at entry. That snapshot costs one acquire load of
+// the epoch and keeps precision and rounding mode consistent for the full
+// operation.
 //
 // Without this, a setter is a silent no-op for any thread that has already
 // executed instrumented arithmetic: the thread copied the default on first use
@@ -253,6 +254,25 @@ inline void refresh_thread_config() {
       default_virtual_precision_f64.load(std::memory_order_relaxed);
   rounding_mode = default_rounding_mode.load(std::memory_order_relaxed);
   observed_epoch = epoch;
+}
+
+struct ConfigSnapshot {
+  int32_t virtual_precision;
+  int32_t rounding_mode;
+};
+
+// Refresh once, then copy the configuration relevant to one arithmetic
+// operation. Callers must reuse this snapshot instead of consulting TLS again
+// midway through the operation.
+template <typename T> inline auto get_config_snapshot() -> ConfigSnapshot {
+  refresh_thread_config();
+  if constexpr (std::is_same_v<T, float>) {
+    return {virtual_precision_f32, rounding_mode};
+  } else if constexpr (std::is_same_v<T, double>) {
+    return {virtual_precision_f64, rounding_mode};
+  } else {
+    static_assert(!sizeof(T), "get_config_snapshot: unsupported type");
+  }
 }
 
 template <typename T> inline auto get_virtual_precision() -> int32_t {

--- a/tests/scalar/BUILD
+++ b/tests/scalar/BUILD
@@ -28,6 +28,11 @@ cc_test_gen_scalar(
     mode = "dynamic",
 )
 
+cc_test_gen_scalar(
+    name = "test_config_epoch",
+    mode = "dynamic",
+)
+
 # Accuracy tests
 
 # Stochastic Rounding rounding mode
@@ -137,6 +142,7 @@ test_suite(
         ":test_twoprodfma",
         ":test_twosum",
         ":test_rn_mode",
+        ":test_config_epoch",
         ":ud-accuracy",
     ],
 )

--- a/tests/scalar/test_config_epoch.cpp
+++ b/tests/scalar/test_config_epoch.cpp
@@ -131,23 +131,18 @@ TEST_F(ConfigEpochTest, RoundingModeReachesARunningThread) {
   auto warmed_up_signal = warmed_up.get_future();
   auto change_signal = mode_changed.get_future();
 
-  int32_t reported = INTERFLOP_PRISM_RN;
-  bool deterministic = false;
+  int32_t kernel_mode = INTERFLOP_PRISM_SR;
+  float after = 0.0F;
 
   std::thread worker([&] {
     (void)srd::addf32(kA, kB);
     warmed_up.set_value();
 
     change_signal.wait();
-    reported = interflop_prism_get_rounding_mode();
-
-    // Under RN the threshold is fixed at one half, so repeating the same
-    // inexact operation is bit-reproducible. Under SR it would not be.
-    const float first = srd::addf32(kA, kB);
-    deterministic = true;
-    for (int i = 0; i < 64; i++) {
-      deterministic = deterministic && (srd::addf32(kA, kB) == first);
-    }
+    // Arithmetic must refresh the worker itself. Reading TLS directly after
+    // the operation avoids letting the public getter mask a stale kernel.
+    after = srd::addf32(kA, kB);
+    kernel_mode = prism::sr::rounding_mode;
   });
 
   warmed_up_signal.wait();
@@ -155,8 +150,8 @@ TEST_F(ConfigEpochTest, RoundingModeReachesARunningThread) {
   mode_changed.set_value();
   worker.join();
 
-  EXPECT_EQ(reported, INTERFLOP_PRISM_RN);
-  EXPECT_TRUE(deterministic);
+  EXPECT_EQ(kernel_mode, INTERFLOP_PRISM_RN);
+  EXPECT_EQ(after, kRoundedAt8);
 }
 
 TEST_F(ConfigEpochTest, ThreadOverrideHoldsUntilTheNextProcessWideSet) {
@@ -198,6 +193,37 @@ TEST_F(ConfigEpochTest, DefaultGetterReportsTheDefaultNotTheThreadValue) {
 
   EXPECT_EQ(interflop_prism_get_virtual_precision_binary32(), 16);
   EXPECT_EQ(interflop_prism_get_default_virtual_precision_binary32(), 16);
+}
+
+TEST_F(ConfigEpochTest, ThreadRoundingModeOverrideHoldsUntilGlobalSet) {
+  std::promise<void> override_set;
+  std::promise<void> default_changed;
+  auto override_signal = override_set.get_future();
+  auto change_signal = default_changed.get_future();
+
+  int32_t under_override = INTERFLOP_PRISM_RN;
+  int32_t after_global_set = INTERFLOP_PRISM_SR;
+
+  std::thread worker([&] {
+    interflop_prism_set_thread_rounding_mode(INTERFLOP_PRISM_SR);
+    under_override = interflop_prism_get_rounding_mode();
+    override_set.set_value();
+
+    change_signal.wait();
+    after_global_set = interflop_prism_get_rounding_mode();
+  });
+
+  override_signal.wait();
+  EXPECT_EQ(interflop_prism_get_rounding_mode(), INTERFLOP_PRISM_RN);
+
+  // Setting the existing default still advances the epoch and discards the
+  // worker's override.
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+  default_changed.set_value();
+  worker.join();
+
+  EXPECT_EQ(under_override, INTERFLOP_PRISM_SR);
+  EXPECT_EQ(after_global_set, INTERFLOP_PRISM_RN);
 }
 
 } // namespace

--- a/tests/scalar/test_config_epoch.cpp
+++ b/tests/scalar/test_config_epoch.cpp
@@ -1,0 +1,203 @@
+// A process-wide precision or rounding-mode change must reach threads that are
+// already running instrumented arithmetic.
+//
+// Both settings live in thread-local storage, seeded from process-wide
+// defaults on first use. Before the config epoch existed, a setter wrote only
+// the default, so it was a silent no-op for every thread that had already
+// rounded once -- while the getter kept reporting the new value. That is the
+// shape of the bug these tests pin down: a worker keeps rounding at the old
+// precision and the caller has no way to tell.
+//
+// An ATen OpenMP team is modelled here by long-lived std::thread workers, which
+// is the property that matters: the thread executed arithmetic before the
+// setter ran, and is still alive after it.
+
+#include <future>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "src/prism_api.h"
+#include "src/sr_scalar.h"
+#include "src/utils.h"
+
+namespace srd = prism::sr::scalar::dynamic_dispatch;
+
+namespace {
+
+// Rounding at t=8 is visibly coarser than at hardware precision: the exact sum
+// is representable in binary32 but not on the t=8 grid, and RN pulls it back to
+// 1.0. A thread stuck at the old precision returns the exact sum instead.
+constexpr float kA = 1.0F;
+constexpr float kB = 0x1.8p-10F;
+constexpr float kExactSum = 0x1.006p0F;  // 1.0 + 1.5 * 2^-10, exact at t=24
+constexpr float kRoundedAt8 = 1.0F;      // nearest multiple of 2^-7
+
+class ConfigEpochTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+    interflop_prism_set_default_virtual_precision_binary32(24);
+    interflop_prism_set_default_virtual_precision_binary64(53);
+  }
+
+  void TearDown() override {
+    interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+    interflop_prism_set_default_virtual_precision_binary32(24);
+    interflop_prism_set_default_virtual_precision_binary64(53);
+  }
+};
+
+TEST_F(ConfigEpochTest, SetReachesAThreadThatAlreadyRounded) {
+  std::promise<void> warmed_up;
+  std::promise<void> precision_changed;
+  auto warmed_up_signal = warmed_up.get_future();
+  auto change_signal = precision_changed.get_future();
+
+  float before = 0.0F;
+  float after = 0.0F;
+  int32_t reported_after = 0;
+
+  std::thread worker([&] {
+    before = srd::addf32(kA, kB);
+    warmed_up.set_value();
+
+    change_signal.wait();
+    after = srd::addf32(kA, kB);
+    reported_after = interflop_prism_get_virtual_precision_binary32();
+  });
+
+  warmed_up_signal.wait();
+  interflop_prism_set_default_virtual_precision_binary32(8);
+  precision_changed.set_value();
+  worker.join();
+
+  EXPECT_EQ(before, kExactSum);
+  EXPECT_EQ(after, kRoundedAt8);
+  EXPECT_EQ(reported_after, 8);
+}
+
+TEST_F(ConfigEpochTest, SetReachesEveryWorkerInAPool) {
+  constexpr size_t kWorkers = 8;
+
+  std::promise<void> precision_changed;
+  auto change_signal = precision_changed.get_future().share();
+  std::vector<std::promise<void>> warmed_up(kWorkers);
+  std::vector<std::future<void>> warmed_up_signals;
+  warmed_up_signals.reserve(kWorkers);
+  for (auto &p : warmed_up) {
+    warmed_up_signals.push_back(p.get_future());
+  }
+
+  std::vector<float> results(kWorkers, 0.0F);
+  std::vector<std::thread> workers;
+  workers.reserve(kWorkers);
+
+  for (size_t i = 0; i < kWorkers; i++) {
+    workers.emplace_back([&, i] {
+      // Round once so the thread caches the current configuration.
+      (void)srd::addf32(kA, kB);
+      warmed_up[i].set_value();
+
+      change_signal.wait();
+      results[i] = srd::addf32(kA, kB);
+    });
+  }
+
+  for (auto &signal : warmed_up_signals) {
+    signal.wait();
+  }
+  interflop_prism_set_default_virtual_precision_binary32(8);
+  precision_changed.set_value();
+  for (auto &worker : workers) {
+    worker.join();
+  }
+
+  for (size_t i = 0; i < kWorkers; i++) {
+    EXPECT_EQ(results[i], kRoundedAt8) << "worker " << i << " kept rounding at "
+                                       << "the precision it cached";
+  }
+}
+
+TEST_F(ConfigEpochTest, RoundingModeReachesARunningThread) {
+  interflop_prism_set_default_virtual_precision_binary32(8);
+  // The worker starts in SR and must end in RN, so a thread that kept the mode
+  // it cached at startup fails rather than passing by coincidence.
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_SR);
+
+  std::promise<void> warmed_up;
+  std::promise<void> mode_changed;
+  auto warmed_up_signal = warmed_up.get_future();
+  auto change_signal = mode_changed.get_future();
+
+  int32_t reported = INTERFLOP_PRISM_RN;
+  bool deterministic = false;
+
+  std::thread worker([&] {
+    (void)srd::addf32(kA, kB);
+    warmed_up.set_value();
+
+    change_signal.wait();
+    reported = interflop_prism_get_rounding_mode();
+
+    // Under RN the threshold is fixed at one half, so repeating the same
+    // inexact operation is bit-reproducible. Under SR it would not be.
+    const float first = srd::addf32(kA, kB);
+    deterministic = true;
+    for (int i = 0; i < 64; i++) {
+      deterministic = deterministic && (srd::addf32(kA, kB) == first);
+    }
+  });
+
+  warmed_up_signal.wait();
+  interflop_prism_set_rounding_mode(INTERFLOP_PRISM_RN);
+  mode_changed.set_value();
+  worker.join();
+
+  EXPECT_EQ(reported, INTERFLOP_PRISM_RN);
+  EXPECT_TRUE(deterministic);
+}
+
+TEST_F(ConfigEpochTest, ThreadOverrideHoldsUntilTheNextProcessWideSet) {
+  std::promise<void> override_set;
+  std::promise<void> default_changed;
+  auto override_signal = override_set.get_future();
+  auto change_signal = default_changed.get_future();
+
+  int32_t under_override = 0;
+  int32_t after_global_set = 0;
+
+  std::thread worker([&] {
+    interflop_prism_set_thread_virtual_precision_binary32(12);
+    under_override = interflop_prism_get_virtual_precision_binary32();
+    override_set.set_value();
+
+    change_signal.wait();
+    after_global_set = interflop_prism_get_virtual_precision_binary32();
+  });
+
+  override_signal.wait();
+  // The main thread keeps the default while the worker runs at 12.
+  EXPECT_EQ(interflop_prism_get_virtual_precision_binary32(), 24);
+  interflop_prism_set_default_virtual_precision_binary32(8);
+  default_changed.set_value();
+  worker.join();
+
+  EXPECT_EQ(under_override, 12);
+  EXPECT_EQ(after_global_set, 8);
+}
+
+TEST_F(ConfigEpochTest, DefaultGetterReportsTheDefaultNotTheThreadValue) {
+  interflop_prism_set_thread_virtual_precision_binary32(10);
+
+  EXPECT_EQ(interflop_prism_get_virtual_precision_binary32(), 10);
+  EXPECT_EQ(interflop_prism_get_default_virtual_precision_binary32(), 24);
+
+  interflop_prism_set_default_virtual_precision_binary32(16);
+
+  EXPECT_EQ(interflop_prism_get_virtual_precision_binary32(), 16);
+  EXPECT_EQ(interflop_prism_get_default_virtual_precision_binary32(), 16);
+}
+
+} // namespace


### PR DESCRIPTION
Virtual precision and rounding mode live in thread-local storage, seeded from process-wide defaults on first use. A thread that had already executed instrumented arithmetic therefore never saw a later change: the precision setter wrote a default no thread re-read, and the rounding-mode setter wrote only the calling thread's slot. Both returned successfully and both getters reported the new value while the arithmetic continued at the old setting, which is the worst shape such a bug can take -- a sweep silently runs at full precision and reports a plausible number.

Reconcile the two with a configuration epoch. A process-wide setter publishes the new value and increments the epoch; each thread compares the epoch against the one it last observed and adopts the new values on its next operation. The check is one relaxed atomic load in get_virtual_precision/get_rounding_mode, which the kernels call once per operation. A throughput comparison over the array interface (median of five runs, both formats, add/mul/div/fma) puts the before/after ratio between 0.99 and 1.02 with no consistent sign.

The API gains getters for the precision a thread will actually round at, as distinct from the default, and explicit per-thread overrides for callers that want threads to round differently; an override holds until the next process-wide set. set_rounding_mode becomes process-wide, matching the precision setter it previously disagreed with.

tests/scalar/test_config_epoch.cpp covers the cases that motivated this: a thread that has already rounded, a pool of such threads, an override surviving until the next global set, and the default getter reporting the default rather than the thread's value. Four of the five fail without the epoch.