### PR TITLE
Fix YAML indentation in release-binaries workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -95,14 +95,14 @@ jobs:
           documentation_root="$package_root/share/doc/prism"
           mkdir -p "$documentation_root"
           install -m 0644 LICENSE README.md "$documentation_root"
-          cat > "$documentation_root/BUILD-INFO.txt" <<EOF
-PRISM version: $version
-Target architecture: $PRISM_ARCH
-Operating system: Linux
-Build image: ubuntu-22.04
-LLVM version: $PRISM_LLVM
-Source revision: $GITHUB_SHA
-EOF
+          cat <<EOF | sed 's/^[[:space:]]*//' > "$documentation_root/BUILD-INFO.txt"
+          PRISM version: $version
+          Target architecture: $PRISM_ARCH
+          Operating system: Linux
+          Build image: ubuntu-22.04
+          LLVM version: $PRISM_LLVM
+          Source revision: $GITHUB_SHA
+          EOF
 
           test -f "$package_root/lib/libprism-dynamic.so"
           test -f "$package_root/lib/libprism-static.so"


### PR DESCRIPTION
## Summary

Fixes a YAML syntax error in `.github/workflows/release-binaries.yml` caused by unindented heredoc text inside a multi-line `run: |` block scalar, which prematurely terminated the scalar and broke YAML parsing on release/push events.