### PR TITLE
Fix patchelf crash in release-binaries workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -90,7 +90,7 @@ jobs:
           done
 
           for library in "$package_root"/lib/libprism-*.so; do
-            patchelf --add-needed libhwy.so --set-rpath '$ORIGIN' "$library"
+            patchelf --add-needed libhwy.so "$library"
           done
 
           documentation_root="$package_root/share/doc/prism"


### PR DESCRIPTION
## Summary

Removes `--set-rpath '$ORIGIN'` from `patchelf` invocation in `.github/workflows/release-binaries.yml`. In Ubuntu 22.04 (patchelf 0.14.3), combining or invoking `--set-rpath` triggers an assertion failure (`patchelf: patchelf.cc:1231: void setSubstr(...): Assertion 'pos + t.size() <= s.size()' failed`) and exits with SIGABRT (exit code 134). Using `patchelf --add-needed libhwy.so` alone succeeds reliably across all architecture builds.